### PR TITLE
Thread-safe lists; registering test reporter for threads

### DIFF
--- a/ReportPortal.Shared/Bridge.cs
+++ b/ReportPortal.Shared/Bridge.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using ReportPortal.Client;
 using System.Reflection;
 using System.Collections.Generic;
@@ -6,6 +7,7 @@ using System.Linq;
 using ReportPortal.Client.Models;
 using ReportPortal.Client.Requests;
 using System.IO;
+using System.Threading;
 
 namespace ReportPortal.Shared
 {
@@ -72,8 +74,32 @@ namespace ReportPortal.Shared
 
             if (!handled && Context.LaunchReporter != null && Context.LaunchReporter.LastTestNode != null)
             {
-                Context.LaunchReporter.LastTestNode.Log(request);
+                var testNode = GetTestReporterForCurrentThread() ?? Context.LaunchReporter.LastTestNode;
+
+                testNode.Log(request);
             }
+        }
+
+        private static readonly ConcurrentBag<KeyValuePair<int, TestReporter>> ThreadTestReporters = new ConcurrentBag<KeyValuePair<int, TestReporter>>();
+
+        public static void RegisterTestReporterForCurrentThread(TestReporter reporter)
+        {
+            RegisterTestReporterForThread(Thread.CurrentThread.ManagedThreadId, reporter);
+        }
+
+        public static void RegisterTestReporterForThread(int threadId, TestReporter reporter)
+        {
+            ThreadTestReporters.Add(new KeyValuePair<int, TestReporter>(threadId, reporter));
+        }
+
+        public static TestReporter GetTestReporterForCurrentThread()
+        {
+            return GetTestReporterForThread(Thread.CurrentThread.ManagedThreadId);
+        }
+
+        public static TestReporter GetTestReporterForThread(int threadId)
+        {
+            return ThreadTestReporters.FirstOrDefault(kv => kv.Key == threadId).Value;
         }
     }
 }

--- a/ReportPortal.Shared/Bridge.cs
+++ b/ReportPortal.Shared/Bridge.cs
@@ -73,17 +73,18 @@ namespace ReportPortal.Shared
 
             if (!handled && Context.LaunchReporter?.LastTestNode != null)
             {
-                var testNode = GetThreadTestReporter() ?? Context.LaunchReporter.LastTestNode;
+                var testNode = GetThreadTestReporter(Thread.CurrentThread.ManagedThreadId) ?? Context.LaunchReporter.LastTestNode;
 
                 testNode.Log(request);
             }
         }
 
-        private static TestReporter GetThreadTestReporter()
+        // TODO need find TestReporter by ID through tree structure
+        private static TestReporter GetThreadTestReporter(int threadId)
         {
             return Context.LaunchReporter?.TestNodes
                 .SelectMany(n => n.TestNodes)
-                .FirstOrDefault(n => n.FinishTask == null && n.ThreadId == Thread.CurrentThread.ManagedThreadId);
+                .FirstOrDefault(n => n.FinishTask == null && n.ThreadId == threadId);
         }
     }
 }

--- a/ReportPortal.Shared/Bridge.cs
+++ b/ReportPortal.Shared/Bridge.cs
@@ -83,8 +83,7 @@ namespace ReportPortal.Shared
         {
             return Context.LaunchReporter?.TestNodes
                 .SelectMany(n => n.TestNodes)
-                .OrderByDescending(n => n.CreateDate)
-                .FirstOrDefault(n => n.ThreadId == Thread.CurrentThread.ManagedThreadId);
+                .FirstOrDefault(n => n.FinishTask == null && n.ThreadId == Thread.CurrentThread.ManagedThreadId);
         }
     }
 }

--- a/ReportPortal.Shared/LaunchReporter.cs
+++ b/ReportPortal.Shared/LaunchReporter.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Net;
+﻿using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 using ReportPortal.Client;
 using ReportPortal.Client.Requests;
@@ -14,7 +14,7 @@ namespace ReportPortal.Shared
         {
             _service = service;
 
-            TestNodes = new List<TestReporter>();
+            TestNodes = new ConcurrentBag<TestReporter>();
         }
 
         public string LaunchId;
@@ -33,13 +33,13 @@ namespace ReportPortal.Shared
             {
                 StartTask.Wait();
 
-                TestNodes.ForEach(tn => tn.FinishTask.Wait());
+                TestNodes.ToList().ForEach(tn => tn.FinishTask.Wait());
 
                 await _service.FinishLaunchAsync(LaunchId, request);
             });
         }
 
-        public List<TestReporter> TestNodes { get; set; }
+        public ConcurrentBag<TestReporter> TestNodes { get; set; }
 
         public TestReporter StartNewTestNode(StartTestItemRequest request)
         {

--- a/ReportPortal.Shared/TestReporter.cs
+++ b/ReportPortal.Shared/TestReporter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ReportPortal.Client;
 using ReportPortal.Client.Requests;
@@ -20,12 +21,18 @@ namespace ReportPortal.Shared
             _service = service;
             _launchNode = launchNode;
             _parentTestNode = parentTestNode;
+
+            ThreadId = Thread.CurrentThread.ManagedThreadId;
+            CreateDate = DateTime.UtcNow;
         }
 
         public string TestId;
 
         public Task StartTask;
         public DateTime StartTime;
+
+        public int ThreadId { get; set; }
+        internal DateTime CreateDate { get; set; }
 
         public void Start(StartTestItemRequest request)
         {

--- a/ReportPortal.Shared/TestReporter.cs
+++ b/ReportPortal.Shared/TestReporter.cs
@@ -23,7 +23,6 @@ namespace ReportPortal.Shared
             _parentTestNode = parentTestNode;
 
             ThreadId = Thread.CurrentThread.ManagedThreadId;
-            CreateDate = DateTime.UtcNow;
         }
 
         public string TestId;
@@ -32,7 +31,6 @@ namespace ReportPortal.Shared
         public DateTime StartTime;
 
         public int ThreadId { get; set; }
-        internal DateTime CreateDate { get; set; }
 
         public void Start(StartTestItemRequest request)
         {

--- a/ReportPortal.Shared/TestReporter.cs
+++ b/ReportPortal.Shared/TestReporter.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 using ReportPortal.Client;
 using ReportPortal.Client.Requests;
-using System;
 
 namespace ReportPortal.Shared
 {
@@ -46,7 +47,7 @@ namespace ReportPortal.Shared
             });
         }
 
-        public List<Task> AdditionalTasks = new List<Task>();
+        public ConcurrentBag<Task> AdditionalTasks = new ConcurrentBag<Task>();
 
         public Task FinishTask;
         public void Finish(FinishTestItemRequest request)
@@ -55,15 +56,15 @@ namespace ReportPortal.Shared
             {
                 StartTask.Wait();
 
-                AdditionalTasks.ForEach(at => at.Wait());
+                AdditionalTasks.ToList().ForEach(at => at.Wait());
 
-                TestNodes.ForEach(tn => tn.FinishTask.Wait());
+                TestNodes.ToList().ForEach(tn => tn.FinishTask.Wait());
 
                 await _service.FinishTestItemAsync(TestId, request);
             });
         }
 
-        public List<TestReporter> TestNodes = new List<TestReporter>();
+        public ConcurrentBag<TestReporter> TestNodes = new ConcurrentBag<TestReporter>();
 
         public TestReporter StartNewTestNode(StartTestItemRequest request)
         {


### PR DESCRIPTION
Replaced `Lists` with `ConcurrentBags` which are thread-safe (I was receiving `IndexOutOfRangeException` on `Add` from time to time).
There is one strange thing about `ConcurrentBag`. When you add an item, it's added to the top of the list. That's why there is `FirstOrDefault` in `GetTestReporterForThread` method.

Added methods to register `TestReporters` for threads to be able to add log items under correct test items. In most cases the log items will be added under the same threads as test items. Obviously it will not work when the log item is added in a separate thread.
Agent should do the registration after creating test items.

I have tested the changes with the new SpecFlow agent with parallel support and it worked correctly.

