### PR TITLE
Find extension only in ReportPortal* assemblies

### DIFF
--- a/ReportPortal.Shared/Bridge.cs
+++ b/ReportPortal.Shared/Bridge.cs
@@ -24,7 +24,7 @@ namespace ReportPortal.Shared
                 AppDomain.CurrentDomain.Load(Path.GetFileNameWithoutExtension(file.Name));
             }
 
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a => a.GetName().Name.StartsWith("ReportPortal")))
             {
                 try
                 {


### PR DESCRIPTION
Approach was:
- Load `ReportPortal*` assemblies to appdomain
- Find ALL types which implements `IBridgeExtension`

`GetTypes()` method is expensive. This PR invoke `GetTypes()` only for ReportPortal* assemblies.

It might resolve #20 issue.