### PR TITLE
Added GA service

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -65,3 +65,10 @@ If you want to redirect agent to send test results into some another way, there 
 - `Launch:Id` (UUID of existing launch) - agent will append test results into provided Launch ID. Launch should be *IN_PROGRESS* state, agent will not finish it. It's your responsibility to start and finish launch. Usefull for distributed test execution, where tests are running on different machines and you want to see consolidated report.
 - `Launch:Rerun` (true/false/yes/no) - agent will try to add new tests into existing launch (compared by name) or adds new attempt/retry for existing tests.
 - `Launch:RerunOf` (UUID of existing launch) - agent will try to add new tests into existing launch (by ID) or adds new attempt/retry for existing tests.
+
+
+# Analytics
+
+Each time when new launch is posted to RP server, reporting engine sends this fact to google analytics service. It doesn't collect sensetive information, just name and version of used engine/agent.
+
+This behavior can be turned off through `Analytics:Enabled` configuration property.

--- a/src/ReportPortal.Shared/Extensibility/Analytics/AnalyticsReportEventsObserver.cs
+++ b/src/ReportPortal.Shared/Extensibility/Analytics/AnalyticsReportEventsObserver.cs
@@ -1,0 +1,122 @@
+﻿using ReportPortal.Shared.Extensibility.ReportEvents;
+using ReportPortal.Shared.Internal.Logging;
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace ReportPortal.Shared.Extensibility.Analytics
+{
+    /// <summary>
+    /// Google Analytics launch events tracker.
+    /// </summary>
+    public class AnalyticsReportEventsObserver : IReportEventsObserver, IDisposable
+    {
+        private const string MEASUREMENT_ID = "UA-168688323-1";
+        private const string BASE_URI = "https://www.google-analytics.com";
+
+        private static ITraceLogger TraceLogger => TraceLogManager.Instance.GetLogger<AnalyticsReportEventsObserver>();
+
+        private readonly string _clientId;
+
+        private readonly string _clientName;
+        private readonly string _clientVersion;
+
+        private HttpClient _httpClient;
+
+        public AnalyticsReportEventsObserver()
+        {
+            _clientId = Guid.NewGuid().ToString();
+
+            // Client is this assembly
+            _clientName = "dotnet-shared";
+            _clientVersion = typeof(AnalyticsReportEventsObserver).Assembly.GetName().Version.ToString(3);
+
+            _httpClient = new HttpClient();
+            _httpClient.BaseAddress = new Uri(BASE_URI);
+        }
+
+        /// <summary>
+        /// Sets custom information about agent name and version. It's expected this method is invoked on agent side.
+        /// </summary>
+        /// <param name="agentName">Human readable name of the agent.</param>
+        /// <param name="agentVersion">Automatically identified as calling assembly version if null.</param>
+        public static void DefineConsumer(string agentName, string agentVersion = null)
+        {
+            AgentName = agentName;
+
+            if (string.IsNullOrEmpty(agentVersion))
+            {
+                var agentAssemblyName = Assembly.GetCallingAssembly().GetName();
+                _agentVersion = agentAssemblyName.Version.ToString(3);
+            }
+            else
+            {
+                _agentVersion = agentVersion;
+            }
+        }
+
+        public static string AgentName { get; private set; } = "Unknown";
+
+        private static string _agentVersion;
+        public static string AgentVersion
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_agentVersion))
+                {
+                    var agentAssemblyName = Assembly.GetCallingAssembly().GetName();
+                    _agentVersion = agentAssemblyName.Version.ToString(3);
+                }
+
+                return _agentVersion;
+            }
+        }
+
+        IReportEventsSource _reportEventsSource;
+
+        public void Initialize(IReportEventsSource reportEventsSource)
+        {
+            _reportEventsSource = reportEventsSource;
+            reportEventsSource.OnBeforeLaunchStarting += ReportEventsSource_OnBeforeLaunchStarting;
+        }
+
+        private void ReportEventsSource_OnBeforeLaunchStarting(Reporter.ILaunchReporter launchReporter, ReportEvents.EventArgs.BeforeLaunchStartingEventArgs args)
+        {
+            if (args.Configuration.GetValue("Analytics:Enabled", true))
+            {
+                var category = $"Client name \"{_clientName}\", version \"{_clientVersion}\"";
+                var label = $"Agent name \"{AgentName}\", version \"{AgentVersion}\"";
+
+                var requestData = $"/collect?v=1&tid={MEASUREMENT_ID}&cid={_clientId}&t=event&ec={category}&ea=Start launch&el={label}";
+
+                // schedule tracking request and forget
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        var response = await _httpClient.PostAsync(requestData, null);
+                        response.EnsureSuccessStatusCode();
+                    }
+                    catch (Exception exp)
+                    {
+                        TraceLogger.Error($"Cannot track OnBeforeLaunchStarting event: {exp}");
+                    }
+                });
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_reportEventsSource != null)
+            {
+                _reportEventsSource.OnBeforeLaunchStarting -= ReportEventsSource_OnBeforeLaunchStarting;
+            }
+
+            if (_httpClient != null)
+            {
+                _httpClient.Dispose();
+            }
+        }
+    }
+}

--- a/src/ReportPortal.Shared/Extensibility/Analytics/AnalyticsReportEventsObserver.cs
+++ b/src/ReportPortal.Shared/Extensibility/Analytics/AnalyticsReportEventsObserver.cs
@@ -12,14 +12,14 @@ namespace ReportPortal.Shared.Extensibility.Analytics
     /// </summary>
     public class AnalyticsReportEventsObserver : IReportEventsObserver, IDisposable
     {
-        private const string MEASUREMENT_ID = "UA-168688323-1";
+        private const string MEASUREMENT_ID = "UA-96321031-1";
         private const string BASE_URI = "https://www.google-analytics.com";
+        private const string CLIENT_NAME = "commons-dotnet";
 
         private static ITraceLogger TraceLogger => TraceLogManager.Instance.GetLogger<AnalyticsReportEventsObserver>();
 
         private readonly string _clientId;
 
-        private readonly string _clientName;
         private readonly string _clientVersion;
 
         private HttpClient _httpClient;
@@ -29,7 +29,6 @@ namespace ReportPortal.Shared.Extensibility.Analytics
             _clientId = Guid.NewGuid().ToString();
 
             // Client is this assembly
-            _clientName = "dotnet-shared";
             _clientVersion = typeof(AnalyticsReportEventsObserver).Assembly.GetName().Version.ToString(3);
 
             _httpClient = new HttpClient();
@@ -56,7 +55,7 @@ namespace ReportPortal.Shared.Extensibility.Analytics
             }
         }
 
-        public static string AgentName { get; private set; } = "Unknown";
+        public static string AgentName { get; private set; } = "Anonymous";
 
         private static string _agentVersion;
         public static string AgentVersion
@@ -75,6 +74,7 @@ namespace ReportPortal.Shared.Extensibility.Analytics
 
         IReportEventsSource _reportEventsSource;
 
+        /// <inheritdoc />
         public void Initialize(IReportEventsSource reportEventsSource)
         {
             _reportEventsSource = reportEventsSource;
@@ -85,7 +85,7 @@ namespace ReportPortal.Shared.Extensibility.Analytics
         {
             if (args.Configuration.GetValue("Analytics:Enabled", true))
             {
-                var category = $"Client name \"{_clientName}\", version \"{_clientVersion}\"";
+                var category = $"Client name \"{CLIENT_NAME}\", version \"{_clientVersion}\"";
                 var label = $"Agent name \"{AgentName}\", version \"{AgentVersion}\"";
 
                 var requestData = $"/collect?v=1&tid={MEASUREMENT_ID}&cid={_clientId}&t=event&ec={category}&ea=Start launch&el={label}";
@@ -106,6 +106,9 @@ namespace ReportPortal.Shared.Extensibility.Analytics
             }
         }
 
+        /// <summary>
+        /// Release HtpClient if needed.
+        /// </summary>
         public void Dispose()
         {
             if (_reportEventsSource != null)

--- a/src/ReportPortal.Shared/Extensibility/ExtensionManager.cs
+++ b/src/ReportPortal.Shared/Extensibility/ExtensionManager.cs
@@ -62,25 +62,28 @@ namespace ReportPortal.Shared.Extensibility
                                 {
                                     foreach (var type in assembly.GetTypes().Where(t => t.IsClass))
                                     {
-                                        if (iLogHandlerExtensionInterfaceType.IsAssignableFrom(type))
+                                        if (!type.IsAbstract && type.GetConstructors().Any(ctor => ctor.GetParameters().Length == 0))
                                         {
-                                            var extension = Activator.CreateInstance(type);
-                                            logHandlers.Add((ILogHandler)extension);
-                                            TraceLogger.Info($"Registered '{type.FullName}' type as {nameof(ILogHandler)} extension.");
-                                        }
+                                            if (iLogHandlerExtensionInterfaceType.IsAssignableFrom(type))
+                                            {
+                                                var extension = Activator.CreateInstance(type);
+                                                logHandlers.Add((ILogHandler)extension);
+                                                TraceLogger.Info($"Registered '{type.FullName}' type as {nameof(ILogHandler)} extension.");
+                                            }
 
-                                        if (iLogFormatterExtensionInterfaceType.IsAssignableFrom(type))
-                                        {
-                                            var extension = Activator.CreateInstance(type);
-                                            logFormatters.Add((ILogFormatter)extension);
-                                            TraceLogger.Info($"Registered '{type.FullName}' type as {nameof(ILogFormatter)} extension.");
-                                        }
+                                            if (iLogFormatterExtensionInterfaceType.IsAssignableFrom(type))
+                                            {
+                                                var extension = Activator.CreateInstance(type);
+                                                logFormatters.Add((ILogFormatter)extension);
+                                                TraceLogger.Info($"Registered '{type.FullName}' type as {nameof(ILogFormatter)} extension.");
+                                            }
 
-                                        if (iReportEventObserseExtensionInterfaceType.IsAssignableFrom(type))
-                                        {
-                                            var extension = Activator.CreateInstance(type);
-                                            reportEventObservers.Add((IReportEventsObserver)extension);
-                                            TraceLogger.Info($"Registered '{type.FullName}' type as {nameof(IReportEventsObserver)} extension.");
+                                            if (iReportEventObserseExtensionInterfaceType.IsAssignableFrom(type))
+                                            {
+                                                var extension = Activator.CreateInstance(type);
+                                                reportEventObservers.Add((IReportEventsObserver)extension);
+                                                TraceLogger.Info($"Registered '{type.FullName}' type as {nameof(IReportEventsObserver)} extension.");
+                                            }
                                         }
                                     }
                                 }

--- a/test/ReportPortal.Shared.Tests/Extensibility/ExtensionManager/ExtensionManagerFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Extensibility/ExtensionManager/ExtensionManagerFixture.cs
@@ -22,6 +22,7 @@ namespace ReportPortal.Shared.Tests.Extensibility.ExtensionManager
 
             manager.LogFormatters.Count.Should().Be(2, "should contain base64 and file built-in formatters");
             manager.LogHandlers.Count.Should().Be(0, "no built-in handlers");
+            manager.ReportEventObservers.Count.Should().Be(1, "google analytic event observer");
         }
     }
 }

--- a/test/ReportPortal.Shared.Tests/ReportPortal.Shared.Tests.csproj
+++ b/test/ReportPortal.Shared.Tests/ReportPortal.Shared.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="WireMock.Net" Version="1.2.12" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/ReportPortal.Shared.Tests/ReportingTest.cs
+++ b/test/ReportPortal.Shared.Tests/ReportingTest.cs
@@ -3,6 +3,7 @@ using ReportPortal.Client.Abstractions.Models;
 using ReportPortal.Client.Abstractions.Requests;
 using ReportPortal.Shared.Configuration;
 using ReportPortal.Shared.Extensibility;
+using ReportPortal.Shared.Extensibility.Analytics;
 using ReportPortal.Shared.Reporter;
 using ReportPortal.Shared.Tests.Helpers;
 using System;
@@ -22,7 +23,12 @@ namespace ReportPortal.Shared.Tests
         [Fact]
         public async Task BigAsyncRealTree()
         {
-            var launchScheduler = new LaunchReporterBuilder(_service);
+            var extManager = new ExtensionManager();
+            var ga = new AnalyticsReportEventsObserver();
+
+            extManager.ReportEventObservers.Add(ga);
+
+            var launchScheduler = new LaunchReporterBuilder(_service).With(extManager);
             var launchReporter = launchScheduler.Build(10, 3, 1);
 
             launchReporter.Sync();


### PR DESCRIPTION
As built-in extension.

All `start launch` invocations will be sent to GA as `Anonymous` until consumer (agent) identifies himself.