### PR TITLE
Support incremental changes in json config files

### DIFF
--- a/src/ReportPortal.Shared/Build/ReportPortal.Shared.props
+++ b/src/ReportPortal.Shared/Build/ReportPortal.Shared.props
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <None Include="ReportPortal.config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/ReportPortal.Shared/Build/net45/ReportPortal.Shared.targets
+++ b/src/ReportPortal.Shared/Build/net45/ReportPortal.Shared.targets
@@ -1,16 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="..\ReportPortal.Shared.props" />
+
   <PropertyGroup>
     <_ReportPortal_Shared_Runtime_Path>$(MSBuildThisFileDirectory)..\..\lib\net45\ReportPortal.Shared.dll</_ReportPortal_Shared_Runtime_Path>
   </PropertyGroup>
-
-  <Target Name="ReportPortal_CopyConfigJsonFile" AfterTargets="BeforeBuild" Condition=" Exists('ReportPortal.config.json') ">
-    <ItemGroup>
-      <None Include="ReportPortal.config.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/ReportPortal.Shared/Build/net46/ReportPortal.Shared.targets
+++ b/src/ReportPortal.Shared/Build/net46/ReportPortal.Shared.targets
@@ -1,16 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="..\ReportPortal.Shared.props" />
+
   <PropertyGroup>
     <_ReportPortal_Shared_Runtime_Path>$(MSBuildThisFileDirectory)..\..\lib\net46\ReportPortal.Shared.dll</_ReportPortal_Shared_Runtime_Path>
   </PropertyGroup>
-
-  <Target Name="ReportPortal_CopyConfigJsonFile" AfterTargets="BeforeBuild" Condition=" Exists('ReportPortal.config.json') ">
-  	<ItemGroup>
-  		<None Include="ReportPortal.config.json">
-  			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  		</None>
-  	</ItemGroup>
-  </Target>
 
 </Project>

--- a/src/ReportPortal.Shared/Build/netstandard2.0/ReportPortal.Shared.targets
+++ b/src/ReportPortal.Shared/Build/netstandard2.0/ReportPortal.Shared.targets
@@ -1,16 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="..\ReportPortal.Shared.props" />
+
   <PropertyGroup>
     <_ReportPortal_Shared_Runtime_Path>$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\ReportPortal.Shared.dll</_ReportPortal_Shared_Runtime_Path>
   </PropertyGroup>
-
-  <Target Name="ReportPortal_CopyConfigJsonFile" AfterTargets="BeforeBuild" Condition=" Exists('ReportPortal.config.json') ">
-    <ItemGroup>
-      <None Include="ReportPortal.config.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/ReportPortal.Shared/ReportPortal.Shared.csproj
+++ b/src/ReportPortal.Shared/ReportPortal.Shared.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <None Include="Build\**\*.targets" Pack="true" PackagePath="build\" />
+    <None Include="Build\**\*.props" Pack="true" PackagePath="build\" />
     
     <None Include="..\..\Logo.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>


### PR DESCRIPTION
The issue: if user doesn't specify explicitly to copy `ReportPortal.config.json` file to output, then package tries to do it by itself. If user makes changes in config file, then build solution, then new version of file is not copied to output. But it works in case of full rebuild solution/project.