### PR TITLE
79 equals method should be defined for metaattribute class

### DIFF
--- a/src/ReportPortal.Shared/Execution/Metadata/MetaAttribute.cs
+++ b/src/ReportPortal.Shared/Execution/Metadata/MetaAttribute.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace ReportPortal.Shared.Execution.Metadata
 {
-    public class MetaAttribute
+    public class MetaAttribute : IEquatable<MetaAttribute>
     {
         public MetaAttribute(string key, string value)
         {
@@ -48,6 +48,23 @@ namespace ReportPortal.Shared.Execution.Metadata
 
             return new MetaAttribute(metaKey, metaValue);
         }
+
+        public bool Equals(MetaAttribute other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other is null || GetType() != other.GetType())
+            {
+                return false;
+            }
+
+            return string.Equals(Key, other.Key) && string.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj) => Equals(obj as MetaAttribute);
 
         public static implicit operator ItemAttribute(MetaAttribute a) => new ItemAttribute { Key = a.Key, Value = a.Value };
     }

--- a/test/ReportPortal.Shared.Tests/Execution/Metadata/MetaAttributeFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Execution/Metadata/MetaAttributeFixture.cs
@@ -37,5 +37,32 @@ namespace ReportPortal.Shared.Tests.Execution.Metadata
             ia.Key.Should().Be("a");
             ia.Value.Should().Be("b");
         }
+
+        [Fact]
+        public void TwoMetaAttributesWithTheSameKeysAndValuesShouldBeEquals()
+        {
+            var firstAttribute = new MetaAttribute("a", "b");
+            var secondAttriute = new MetaAttribute("a", "b");
+
+            firstAttribute.Should().BeEquivalentTo(secondAttriute);
+        }
+
+        [Fact]
+        public void TwoMetaAttributesWithDifferentKeysShouldNotBeEquals()
+        {
+            var firstAttribute = new MetaAttribute("a", "b");
+            var secondAttriute = new MetaAttribute("c", "b");
+
+            firstAttribute.Should().NotBeEquivalentTo(secondAttriute);
+        }
+
+        [Fact]
+        public void TowMetaAttributesWithDifferentValuesShouldNotBeEquals()
+        {
+            var firstAttribute = new MetaAttribute("a", "b");
+            var secondAttriute = new MetaAttribute("a", "c");
+
+            firstAttribute.Should().NotBeEquivalentTo(secondAttriute);
+        }
     }
 }

--- a/test/ReportPortal.Shared.Tests/Execution/TestMetadataFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Execution/TestMetadataFixture.cs
@@ -20,6 +20,22 @@ namespace ReportPortal.Shared.Tests.Execution
         }
 
         [Fact]
+        public void ShouldNotContainDuplicateAttributes()
+        {
+            var testContext = new TestContext(new ExtensionManager(), new CommandsSource(null));
+            testContext.Metadata.Attributes.Add(new MetaAttribute("a", "b"));
+
+            var duplicate = new MetaAttribute("a", "b");
+
+            if (!testContext.Metadata.Attributes.Contains(duplicate))
+            {
+                testContext.Metadata.Attributes.Add(duplicate);
+            }
+
+            testContext.Metadata.Attributes.Count.Should().Be(1);
+        }
+
+        [Fact]
         public void ShouldRaiseOnGetAttributes()
         {
             var mockListener = new Mock<ICommandsListener>();


### PR DESCRIPTION
- Implemented `IEquatable<T>` interface for `MetaAttribute` class.
- Added tests for checking Meta Attribute equivalence.