### PR TITLE
Configurable logs batch capacity for processing log messages

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -61,6 +61,9 @@ See the list of supported status codes [here](https://learn.microsoft.com/en-us/
 ## Throttle requests
 Configure `Server:MaximumConnectionsNumber` property to set the maximum number of concurrent requests (default is `10`).
 
+## Batching log messages
+If your test produces a lot of log messages shortly, then they, most likely, will be sent as single http request. `Server:LogsBatchCapacity` says how many log messages can be combined as 1 request (default is `20`).
+
 ## Retry requests
 Set `Server:Retry:Strategy` property to `Exponential` (default) or `Linear` or `None`.
 

--- a/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
+++ b/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
@@ -12,6 +12,8 @@
         public static readonly string ServerProject = $"Server{KeyDelimeter}Project";
         public static readonly string ServerAuthenticationUuid = $"Server{KeyDelimeter}Authentication{KeyDelimeter}Uuid";
 
+        public static readonly string LogsBatchCapacity = $"Server{KeyDelimeter}LogsBatchCapacity";
+
         public static readonly string LaunchName = $"Launch{KeyDelimeter}Name";
         public static readonly string LaunchDescription = $"Launch{KeyDelimeter}Description";
         public static readonly string LaunchDebugMode = $"Launch{KeyDelimeter}DebugMode";

--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -291,7 +291,10 @@ namespace ReportPortal.Shared.Reporter
                     if (_logsReporter == null)
                     {
                         var logRequestAmender = new LaunchLogRequestAmender(this);
-                        _logsReporter = new LogsReporter(this, _service, _configuration, _extensionManager, _requestExecuter, logRequestAmender, _reportEventsSource);
+
+                        var logsBatchCapacity = _configuration.GetValue<int>(ConfigurationPath.LogsBatchCapacity, 20);
+
+                        _logsReporter = new LogsReporter(this, _service, _configuration, _extensionManager, _requestExecuter, logRequestAmender, _reportEventsSource, logsBatchCapacity);
                     }
                 }
 

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -33,7 +33,8 @@ namespace ReportPortal.Shared.Reporter
                             IExtensionManager extensionManager,
                             IRequestExecuter requestExecuter,
                             ILogRequestAmender logRequestAmender,
-                            ReportEventsSource reportEventsSource)
+                            ReportEventsSource reportEventsSource,
+                            int batchCapacity)
         {
             _reporter = testReporter;
             _service = service;
@@ -42,11 +43,14 @@ namespace ReportPortal.Shared.Reporter
             _requestExecuter = requestExecuter;
             _logRequestAmender = logRequestAmender;
             _reportEventsSource = reportEventsSource;
+
+            if (batchCapacity < 1) throw new ArgumentException("Batch capacity for logs processing cannot be less than 1.", nameof(batchCapacity));
+            BatchCapacity = batchCapacity;
         }
 
         private readonly object _syncObj = new object();
 
-        public int BatchCapacity { get; set; } = 10;
+        public int BatchCapacity { get; }
 
         public void Log(CreateLogItemRequest logRequest)
         {

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -278,7 +278,10 @@ namespace ReportPortal.Shared.Reporter
                     if (_logsReporter == null)
                     {
                         var logRequestAmender = new TestLogRequestAmender(this);
-                        _logsReporter = new LogsReporter(this, _service, _configuration, _extensionManager, _requestExecuter, logRequestAmender, _reportEventsSource);
+
+                        var logsBatchCapacity = _configuration.GetValue<int>(ConfigurationPath.LogsBatchCapacity, 20);
+
+                        _logsReporter = new LogsReporter(this, _service, _configuration, _extensionManager, _requestExecuter, logRequestAmender, _reportEventsSource, logsBatchCapacity);
                     }
                 }
 

--- a/test/ReportPortal.Shared.Tests/Helpers/LaunchReporterBuilder.cs
+++ b/test/ReportPortal.Shared.Tests/Helpers/LaunchReporterBuilder.cs
@@ -71,7 +71,7 @@ namespace ReportPortal.Shared.Tests.Helpers
                         testNode.Log(new CreateLogItemRequest
                         {
                             Level = LogLevel.Info,
-                            Text = $"Log message #{l}",
+                            Text = $"Log message #{l:D5}",
                             Time = launchDateTime
                         });
                     }

--- a/test/ReportPortal.Shared.Tests/Reporter/ReporterTest.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/ReporterTest.cs
@@ -346,7 +346,7 @@ namespace ReportPortal.Shared.Tests.Reporter
             launchReporter.Sync();
 
             service.Verify(s => s.Launch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>()), Times.Once);
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.AtLeast(30 * 30 / 10)); // logs buffer size
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.AtLeast(30 * 30 / 20)); // logs batch size
 
             foreach (var bufferedRequests in requests)
             {


### PR DESCRIPTION
Resolves #117 

- Property name is `Launch:LogsBatchCapacity`
- Default is `20`