### PR TITLE
Use v2 async controllers for posting launch/test/log

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -41,8 +41,8 @@ Sometimes it's useful to specify configuration properties via environment variab
 ## Timeout
 `Server:Timeout` - how many seconds to wait when awaiting response from server.
 
-## ApiVersion
-`Server:ApiVersion` - ReportPortal API version to use (default version is 1). Version 2 is available partially (please have a look, what endpoints are available [here](https://github.com/reportportal/client-net/tree/develop/src/ReportPortal.Client/Resources)).
+## AsyncReporting
+`Server:AsyncReporting` - statement of using async endpoints (default value is false).
 
 # HTTP requests retry
 During tests execution agent sends test results as http requests to server. In case of fast test execution, or parallel tests execution, agent produces many requests to server. These requests are being sent in background and in parallel. Some requests might be failed due any reason e.g. short-term service unavailability, or network bandwith. To negotiate this issue several methodics can be applied.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -41,8 +41,8 @@ Sometimes it's useful to specify configuration properties via environment variab
 ## Timeout
 `Server:Timeout` - how many seconds to wait when awaiting response from server.
 
-## AsyncReporting
-`Server:AsyncReporting` - statement of using async endpoints (default value is false).
+## Asynchronous reporting
+`Server:AsyncReporting` - [asynchronous report](https://reportportal.io/docs/dev-guides/AsynchronousReporting) processing on server side (`false` by default). It gives a response back immediately after a server that is receiving a request from a client. Useful when you have a lot of tests which produce a lot of log messages to be sent to a server.
 
 # HTTP requests retry
 During tests execution agent sends test results as http requests to server. In case of fast test execution, or parallel tests execution, agent produces many requests to server. These requests are being sent in background and in parallel. Some requests might be failed due any reason e.g. short-term service unavailability, or network bandwith. To negotiate this issue several methodics can be applied.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -41,6 +41,9 @@ Sometimes it's useful to specify configuration properties via environment variab
 ## Timeout
 `Server:Timeout` - how many seconds to wait when awaiting response from server.
 
+## ApiVersion
+`Server:ApiVersion` - ReportPortal API version to use (default version is 1). Version 2 is available partially (please have a look, what endpoints are available [here](https://github.com/reportportal/client-net/tree/develop/src/ReportPortal.Client/Resources)).
+
 # HTTP requests retry
 During tests execution agent sends test results as http requests to server. In case of fast test execution, or parallel tests execution, agent produces many requests to server. These requests are being sent in background and in parallel. Some requests might be failed due any reason e.g. short-term service unavailability, or network bandwith. To negotiate this issue several methodics can be applied.
 

--- a/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
+++ b/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
@@ -13,6 +13,7 @@
         public static readonly string ServerAuthenticationUuid = $"Server{KeyDelimeter}Authentication{KeyDelimeter}Uuid";
 
         public static readonly string LogsBatchCapacity = $"Server{KeyDelimeter}LogsBatchCapacity";
+        public static readonly string ApiVersion = $"Server{KeyDelimeter}ApiVersion";
 
         public static readonly string LaunchName = $"Launch{KeyDelimeter}Name";
         public static readonly string LaunchDescription = $"Launch{KeyDelimeter}Description";

--- a/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
+++ b/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
@@ -13,7 +13,7 @@
         public static readonly string ServerAuthenticationUuid = $"Server{KeyDelimeter}Authentication{KeyDelimeter}Uuid";
 
         public static readonly string LogsBatchCapacity = $"Server{KeyDelimeter}LogsBatchCapacity";
-        public static readonly string ApiVersion = $"Server{KeyDelimeter}ApiVersion";
+        public static readonly string AsyncReporting = $"Server{KeyDelimeter}AsyncReporting";
 
         public static readonly string LaunchName = $"Launch{KeyDelimeter}Name";
         public static readonly string LaunchDescription = $"Launch{KeyDelimeter}Description";

--- a/src/ReportPortal.Shared/ReportPortal.Shared.csproj
+++ b/src/ReportPortal.Shared/ReportPortal.Shared.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-        <PackageReference Include="ReportPortal.Client" Version="3.3.0-alpha.12">
+        <PackageReference Include="ReportPortal.Client" Version="3.3.0-alpha.14">
       <PrivateAssets>contentfiles;analyzers;</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -18,6 +18,7 @@ namespace ReportPortal.Shared.Reporter
     {
         private Internal.Logging.ITraceLogger TraceLogger { get; } = Internal.Logging.TraceLogManager.Instance.GetLogger<LaunchReporter>();
 
+        private readonly bool _asyncReporting;
         private readonly IConfiguration _configuration;
         private readonly IClientService _service;
         private readonly IRequestExecuter _requestExecuter;
@@ -43,6 +44,7 @@ namespace ReportPortal.Shared.Reporter
                 _configuration = new ConfigurationBuilder().AddDefaults(configurationDirectory).Build();
             }
 
+            _asyncReporting = _configuration.GetValue(ConfigurationPath.AsyncReporting, false);
             _requestExecuter = requestExecuter ?? new RequestExecuterFactory(_configuration).Create();
 
             _extensionManager = extensionManager ?? throw new ArgumentNullException(nameof(extensionManager));
@@ -119,9 +121,9 @@ namespace ReportPortal.Shared.Reporter
                     NotifyStarting(request);
 
                     var launch = await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
-                                ? _service.AsyncLaunch.StartAsync(request)
-                                : _service.Launch.StartAsync(request), null, null)
+                        .ExecuteAsync(() => _asyncReporting
+                            ? _service.AsyncLaunch.StartAsync(request)
+                            : _service.Launch.StartAsync(request), null, null)
                         .ConfigureAwait(false);
 
                     _launchInfo = new LaunchInfo
@@ -238,7 +240,7 @@ namespace ReportPortal.Shared.Reporter
                         NotifyFinishing(request);
 
                         var launchFinishedResponse = await _requestExecuter
-                            .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
+                            .ExecuteAsync(() => _asyncReporting
                                 ? _service.AsyncLaunch.FinishAsync(Info.Uuid, request)
                                 : _service.Launch.FinishAsync(Info.Uuid, request), null, null)
                             .ConfigureAwait(false);

--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -9,6 +9,8 @@ using ReportPortal.Shared.Extensibility;
 using ReportPortal.Shared.Extensibility.ReportEvents.EventArgs;
 using ReportPortal.Shared.Internal.Delegating;
 using ReportPortal.Shared.Reporter.Statistics;
+using ReportPortal.Client.Abstractions.Responses;
+using System.Threading;
 
 namespace ReportPortal.Shared.Reporter
 {
@@ -116,7 +118,11 @@ namespace ReportPortal.Shared.Reporter
                 {
                     NotifyStarting(request);
 
-                    var launch = await _requestExecuter.ExecuteAsync(() => _service.Launch.StartAsync(request), null, null).ConfigureAwait(false);
+                    var launch = await _requestExecuter
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                                ? _service.AsyncLaunch.StartAsync(request)
+                                : _service.Launch.StartAsync(request), null, null)
+                        .ConfigureAwait(false);
 
                     _launchInfo = new LaunchInfo
                     {
@@ -231,7 +237,11 @@ namespace ReportPortal.Shared.Reporter
                     {
                         NotifyFinishing(request);
 
-                        var launchFinishedResponse = await _requestExecuter.ExecuteAsync(() => _service.Launch.FinishAsync(Info.Uuid, request), null, null).ConfigureAwait(false);
+                        var launchFinishedResponse = await _requestExecuter
+                            .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                                ? _service.AsyncLaunch.FinishAsync(Info.Uuid, request)
+                                : _service.Launch.FinishAsync(Info.Uuid, request), null, null)
+                            .ConfigureAwait(false);
 
                         _launchInfo.FinishTime = request.EndTime;
                         _launchInfo.Url = launchFinishedResponse.Link;

--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -119,7 +119,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyStarting(request);
 
                     var launch = await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
                                 ? _service.AsyncLaunch.StartAsync(request)
                                 : _service.Launch.StartAsync(request), null, null)
                         .ConfigureAwait(false);
@@ -238,7 +238,7 @@ namespace ReportPortal.Shared.Reporter
                         NotifyFinishing(request);
 
                         var launchFinishedResponse = await _requestExecuter
-                            .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                            .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
                                 ? _service.AsyncLaunch.FinishAsync(Info.Uuid, request)
                                 : _service.Launch.FinishAsync(Info.Uuid, request), null, null)
                             .ConfigureAwait(false);

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -78,7 +78,11 @@ namespace ReportPortal.Shared.Reporter
 
                                 NotifySending(requests);
 
-                                await _requestExecuter.ExecuteAsync(async () => await _service.LogItem.CreateAsync(requests.ToArray()), null, _reporter.StatisticsCounter.LogItemStatisticsCounter).ConfigureAwait(false);
+                                await _requestExecuter
+                                    .ExecuteAsync(async () => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                                        ? await _service.AsyncLogItem.CreateAsync(requests.ToArray())
+                                        : await _service.LogItem.CreateAsync(requests.ToArray()), null, _reporter.StatisticsCounter.LogItemStatisticsCounter)
+                                    .ConfigureAwait(false);
 
                                 NotifySent(requests.AsReadOnly());
                             }

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -45,7 +45,7 @@ namespace ReportPortal.Shared.Reporter
             _requestExecuter = requestExecuter;
             _logRequestAmender = logRequestAmender;
             _reportEventsSource = reportEventsSource;
-            _asyncReporting = _configuration?.GetValue(ConfigurationPath.AsyncReporting, false) ?? false;
+            _asyncReporting = _configuration.GetValue(ConfigurationPath.AsyncReporting, false);
 
             if (batchCapacity < 1) throw new ArgumentException("Batch capacity for logs processing cannot be less than 1.", nameof(batchCapacity));
             BatchCapacity = batchCapacity;

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -79,7 +79,7 @@ namespace ReportPortal.Shared.Reporter
                                 NotifySending(requests);
 
                                 await _requestExecuter
-                                    .ExecuteAsync(async () => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                                    .ExecuteAsync(async () => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
                                         ? await _service.AsyncLogItem.CreateAsync(requests.ToArray())
                                         : await _service.LogItem.CreateAsync(requests.ToArray()), null, _reporter.StatisticsCounter.LogItemStatisticsCounter)
                                     .ConfigureAwait(false);

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -38,7 +38,7 @@ namespace ReportPortal.Shared.Reporter
             _requestExecuter = requestExecuter;
             _extensionManager = extensionManager;
             _reportEventsSource = reportEventNotifier;
-            _asyncReporting = _configuration?.GetValue(ConfigurationPath.AsyncReporting, false) ?? false;
+            _asyncReporting = _configuration.GetValue(ConfigurationPath.AsyncReporting, false);
 
             LaunchReporter = launchReporter;
             ParentTestReporter = parentTestReporter;

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -15,6 +15,7 @@ namespace ReportPortal.Shared.Reporter
 {
     public class TestReporter : ITestReporter
     {
+        private readonly bool _asyncReporting;
         private readonly IClientService _service;
         private readonly IConfiguration _configuration;
         private readonly IRequestExecuter _requestExecuter;
@@ -37,6 +38,8 @@ namespace ReportPortal.Shared.Reporter
             _requestExecuter = requestExecuter;
             _extensionManager = extensionManager;
             _reportEventsSource = reportEventNotifier;
+            _asyncReporting = _configuration?.GetValue(ConfigurationPath.AsyncReporting, false) ?? false;
+
             LaunchReporter = launchReporter;
             ParentTestReporter = parentTestReporter;
         }
@@ -88,7 +91,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyStarting(startTestItemRequest);
 
                     var testModel = await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
+                        .ExecuteAsync(() => _asyncReporting
                             ? _service.AsyncTestItem.StartAsync(startTestItemRequest)
                             : _service.TestItem.StartAsync(startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter)
                         .ConfigureAwait(false);
@@ -107,7 +110,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyStarting(startTestItemRequest);
 
                     var testModel = await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
+                        .ExecuteAsync(() => _asyncReporting
                             ? _service.AsyncTestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest)
                             : _service.TestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter)
                         .ConfigureAwait(false);
@@ -216,7 +219,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyFinishing(request);
 
                     await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
+                        .ExecuteAsync(() => _asyncReporting
                             ? _service.AsyncTestItem.FinishAsync(Info.Uuid, request)
                             : _service.TestItem.FinishAsync(Info.Uuid, request), null, LaunchReporter.StatisticsCounter.FinishTestItemStatisticsCounter)
                         .ConfigureAwait(false);

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -88,7 +88,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyStarting(startTestItemRequest);
 
                     var testModel = await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
                             ? _service.AsyncTestItem.StartAsync(startTestItemRequest)
                             : _service.TestItem.StartAsync(startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter)
                         .ConfigureAwait(false);
@@ -107,7 +107,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyStarting(startTestItemRequest);
 
                     var testModel = await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
                             ? _service.AsyncTestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest)
                             : _service.TestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter)
                         .ConfigureAwait(false);
@@ -216,7 +216,7 @@ namespace ReportPortal.Shared.Reporter
                     NotifyFinishing(request);
 
                     await _requestExecuter
-                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.AsyncReporting, false)
                             ? _service.AsyncTestItem.FinishAsync(Info.Uuid, request)
                             : _service.TestItem.FinishAsync(Info.Uuid, request), null, LaunchReporter.StatisticsCounter.FinishTestItemStatisticsCounter)
                         .ConfigureAwait(false);

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -87,7 +87,11 @@ namespace ReportPortal.Shared.Reporter
                 {
                     NotifyStarting(startTestItemRequest);
 
-                    var testModel = await _requestExecuter.ExecuteAsync(() => _service.TestItem.StartAsync(startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter).ConfigureAwait(false);
+                    var testModel = await _requestExecuter
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                            ? _service.AsyncTestItem.StartAsync(startTestItemRequest)
+                            : _service.TestItem.StartAsync(startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter)
+                        .ConfigureAwait(false);
 
                     _testInfo = new TestInfo
                     {
@@ -102,7 +106,11 @@ namespace ReportPortal.Shared.Reporter
                 {
                     NotifyStarting(startTestItemRequest);
 
-                    var testModel = await _requestExecuter.ExecuteAsync(() => _service.TestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter).ConfigureAwait(false);
+                    var testModel = await _requestExecuter
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                            ? _service.AsyncTestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest)
+                            : _service.TestItem.StartAsync(ParentTestReporter.Info.Uuid, startTestItemRequest), null, LaunchReporter.StatisticsCounter.StartTestItemStatisticsCounter)
+                        .ConfigureAwait(false);
 
                     _testInfo = new TestInfo
                     {
@@ -207,7 +215,11 @@ namespace ReportPortal.Shared.Reporter
 
                     NotifyFinishing(request);
 
-                    await _requestExecuter.ExecuteAsync(() => _service.TestItem.FinishAsync(Info.Uuid, request), null, LaunchReporter.StatisticsCounter.FinishTestItemStatisticsCounter).ConfigureAwait(false);
+                    await _requestExecuter
+                        .ExecuteAsync(() => _configuration.GetValue(ConfigurationPath.ApiVersion, 1) == 2
+                            ? _service.AsyncTestItem.FinishAsync(Info.Uuid, request)
+                            : _service.TestItem.FinishAsync(Info.Uuid, request), null, LaunchReporter.StatisticsCounter.FinishTestItemStatisticsCounter)
+                        .ConfigureAwait(false);
 
                     _testInfo.FinishTime = request.EndTime;
                     _testInfo.Status = request.Status;

--- a/test/ReportPortal.Shared.Benchmark/Reporter/NopService.cs
+++ b/test/ReportPortal.Shared.Benchmark/Reporter/NopService.cs
@@ -24,28 +24,18 @@ namespace ReportPortal.Shared.Benchmark.Reporter
 
         public IProjectResource Project => throw new NotImplementedException();
 
-        public IAsyncLaunchResource AsyncLaunch => throw new NotImplementedException();
+        public IAsyncLaunchResource AsyncLaunch => new NopAsyncLaunchResource();
 
-        public IAsyncTestItemResource AsyncTestItem => throw new NotImplementedException();
+        public IAsyncTestItemResource AsyncTestItem => new NopAsyncTestItemResource();
 
-        public IAsyncLogItemResource AsyncLogItem => throw new NotImplementedException();
+        public IAsyncLogItemResource AsyncLogItem => new NopAsyncLogItemResource();
     }
 
     public class NopLaunchResource : ILaunchResource
     {
-        public async Task<MessageResponse> AnalyzeAsync(AnalyzeLaunchRequest model)
-        {
-            return await AnalyzeAsync(model, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public Task<MessageResponse> AnalyzeAsync(AnalyzeLaunchRequest request, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
-        }
-
-        public async Task<MessageResponse> DeleteAsync(long id)
-        {
-            return await DeleteAsync(id, CancellationToken.None).ConfigureAwait(false);
         }
 
         public Task<MessageResponse> DeleteAsync(long id, CancellationToken cancellationToken)
@@ -53,29 +43,9 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             throw new NotImplementedException();
         }
 
-        public async Task<LaunchFinishedResponse> FinishAsync(string uuid, FinishLaunchRequest model)
-        {
-            return await FinishAsync(uuid, model, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public async Task<LaunchFinishedResponse> FinishAsync(string uuid, FinishLaunchRequest request, CancellationToken cancellationToken)
         {
             return await Task.FromResult(new LaunchFinishedResponse());
-        }
-
-        public async Task<LaunchResponse> GetAsync(long id)
-        {
-            return await GetAsync(id, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public async Task<LaunchResponse> GetAsync(string uuid)
-        {
-            return await GetAsync(uuid, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public async Task<Content<LaunchResponse>> GetAsync(FilterOption filterOption)
-        {
-            return await GetAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
         }
 
         public Task<LaunchResponse> GetAsync(long id, CancellationToken cancellationToken)
@@ -88,11 +58,6 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             throw new NotImplementedException();
         }
 
-        public async Task<Content<LaunchResponse>> GetAsync()
-        {
-            return await GetAsync(CancellationToken.None).ConfigureAwait(false);
-        }
-
         public async Task<Content<LaunchResponse>> GetAsync(CancellationToken cancellationToken)
         {
             return await GetAsync(filterOption: null, cancellationToken).ConfigureAwait(false);
@@ -101,16 +66,6 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         public Task<Content<LaunchResponse>> GetAsync(FilterOption filterOption, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
-        }
-
-        public async Task<Content<LaunchResponse>> GetDebugAsync(FilterOption filterOption)
-        {
-            return await GetDebugAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public async Task<Content<LaunchResponse>> GetDebugAsync()
-        {
-            return await GetDebugAsync(filterOption: null, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task<Content<LaunchResponse>> GetDebugAsync(CancellationToken cancellationToken)
@@ -123,19 +78,9 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             throw new NotImplementedException();
         }
 
-        public async Task<LaunchResponse> MergeAsync(MergeLaunchesRequest model)
-        {
-            return await MergeAsync(model, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public Task<LaunchResponse> MergeAsync(MergeLaunchesRequest request, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
-        }
-
-        public async Task<LaunchCreatedResponse> StartAsync(StartLaunchRequest request)
-        {
-            return await StartAsync(request, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task<LaunchCreatedResponse> StartAsync(StartLaunchRequest request, CancellationToken cancellationToken)
@@ -143,19 +88,9 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             return await Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() });
         }
 
-        public async Task<LaunchFinishedResponse> StopAsync(long id, FinishLaunchRequest model)
-        {
-            return await StopAsync(id, model, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public Task<LaunchFinishedResponse> StopAsync(long id, FinishLaunchRequest request, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
-        }
-
-        public async Task<MessageResponse> UpdateAsync(long id, UpdateLaunchRequest model)
-        {
-            return await UpdateAsync(id, model, CancellationToken.None).ConfigureAwait(false);
         }
 
         public Task<MessageResponse> UpdateAsync(long id, UpdateLaunchRequest request, CancellationToken cancellationToken)
@@ -164,21 +99,29 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         }
     }
 
-    public class NopTestItemResource : ITestItemResource
+    public class NopAsyncLaunchResource : IAsyncLaunchResource
     {
-        public async Task<IEnumerable<Issue>> AssignIssuesAsync(AssignTestItemIssuesRequest model)
+        public async Task<LaunchFinishedResponse> FinishAsync(string uuid, FinishLaunchRequest request, CancellationToken cancellationToken = default)
         {
-            return await AssignIssuesAsync(model, CancellationToken.None).ConfigureAwait(false);
+            return await Task.FromResult(new LaunchFinishedResponse());
         }
 
-        public Task<IEnumerable<Issue>> AssignIssuesAsync(AssignTestItemIssuesRequest request, CancellationToken cancellationToken)
+        public Task<LaunchResponse> MergeAsync(MergeLaunchesRequest request, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public async Task<MessageResponse> DeleteAsync(long id)
+        public async Task<LaunchCreatedResponse> StartAsync(StartLaunchRequest request, CancellationToken cancellationToken = default)
         {
-            return await DeleteAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return await Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() });
+        }
+    }
+
+    public class NopTestItemResource : ITestItemResource
+    {
+        public Task<IEnumerable<Issue>> AssignIssuesAsync(AssignTestItemIssuesRequest request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
 
         public Task<MessageResponse> DeleteAsync(long id, CancellationToken cancellationToken)
@@ -186,29 +129,14 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             throw new NotImplementedException();
         }
 
-        public async Task<MessageResponse> FinishAsync(string id, FinishTestItemRequest model)
-        {
-            return await FinishAsync(id, model, CancellationToken.None);
-        }
-
         public async Task<MessageResponse> FinishAsync(string uuid, FinishTestItemRequest request, CancellationToken cancellationToken)
         {
             return await Task.FromResult(new MessageResponse());
         }
 
-        public async Task<TestItemResponse> GetAsync(long id)
-        {
-            return await GetAsync(id, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public async Task<TestItemResponse> GetAsync(string uuid)
         {
             return await GetAsync(uuid, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public async Task<Content<TestItemResponse>> GetAsync(FilterOption filterOption)
-        {
-            return await GetAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
         }
 
         public Task<TestItemResponse> GetAsync(long id, CancellationToken cancellationToken)
@@ -221,11 +149,6 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             throw new NotImplementedException();
         }
 
-        public Task<Content<TestItemResponse>> GetAsync()
-        {
-            return GetAsync(filterOption: null, CancellationToken.None);
-        }
-
         public Task<Content<TestItemResponse>> GetAsync(CancellationToken cancellationToken)
         {
             return GetAsync(filterOption: null, cancellationToken);
@@ -236,24 +159,9 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             throw new NotImplementedException();
         }
 
-        public async Task<Content<TestItemHistoryContainer>> GetHistoryAsync(long testItemId, int depth)
-        {
-            return await GetHistoryAsync(testItemId, depth, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public Task<Content<TestItemHistoryContainer>> GetHistoryAsync(long id, int depth, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
-        }
-
-        public async Task<TestItemCreatedResponse> StartAsync(StartTestItemRequest model)
-        {
-            return await StartAsync(model, CancellationToken.None);
-        }
-
-        public async Task<TestItemCreatedResponse> StartAsync(string uuid, StartTestItemRequest model)
-        {
-            return await StartAsync(uuid, model, CancellationToken.None);
         }
 
         public async Task<TestItemCreatedResponse> StartAsync(StartTestItemRequest request, CancellationToken cancellationToken)
@@ -266,14 +174,27 @@ namespace ReportPortal.Shared.Benchmark.Reporter
             return await Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() });
         }
 
-        public async Task<MessageResponse> UpdateAsync(long id, UpdateTestItemRequest model)
-        {
-            return await UpdateAsync(id, model, CancellationToken.None).ConfigureAwait(false);
-        }
-
         public Task<MessageResponse> UpdateAsync(long id, UpdateTestItemRequest request, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
+        }
+    }
+
+    public class NopAsyncTestItemResource : IAsyncTestItemResource
+    {
+        public async Task<MessageResponse> FinishAsync(string uuid, FinishTestItemRequest request, CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult(new MessageResponse());
+        }
+
+        public async Task<TestItemCreatedResponse> StartAsync(StartTestItemRequest request, CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() });
+        }
+
+        public async Task<TestItemCreatedResponse> StartAsync(string uuid, StartTestItemRequest model, CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() });
         }
     }
 
@@ -357,6 +278,19 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         public Task<byte[]> GetBinaryDataAsync(string id, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
+        }
+    }
+
+    public class NopAsyncLogItemResource : IAsyncLogItemResource
+    {
+        public async Task<LogItemCreatedResponse> CreateAsync(CreateLogItemRequest request, CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult(new LogItemCreatedResponse());
+        }
+
+        public async Task<LogItemsCreatedResponse> CreateAsync(CreateLogItemRequest[] requests, CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult(new LogItemsCreatedResponse());
         }
     }
 }

--- a/test/ReportPortal.Shared.Benchmark/Reporter/NopService.cs
+++ b/test/ReportPortal.Shared.Benchmark/Reporter/NopService.cs
@@ -23,6 +23,12 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         public IUserFilterResource UserFilter => throw new NotImplementedException();
 
         public IProjectResource Project => throw new NotImplementedException();
+
+        public IAsyncLaunchResource AsyncLaunch => throw new NotImplementedException();
+
+        public IAsyncTestItemResource AsyncTestItem => throw new NotImplementedException();
+
+        public IAsyncLogItemResource AsyncLogItem => throw new NotImplementedException();
     }
 
     public class NopLaunchResource : ILaunchResource

--- a/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
+++ b/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
@@ -19,7 +19,7 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         public void LaunchReporter()
         {
             var configuration = new Configuration.ConfigurationBuilder().Build();
-            configuration.Properties[ConfigurationPath.ApiVersion] = 2;
+            configuration.Properties[ConfigurationPath.AsyncReporting] = true;
 
             var nopService = new NopService();
             var launchReporter = new LaunchReporter(nopService, configuration, null, new ExtensionManager());

--- a/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
+++ b/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
 using ReportPortal.Client.Abstractions.Models;
 using ReportPortal.Client.Abstractions.Requests;
+using ReportPortal.Shared.Configuration;
 using ReportPortal.Shared.Extensibility;
 using ReportPortal.Shared.Reporter;
 using System;
@@ -18,6 +19,7 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         public void LaunchReporter()
         {
             var configuration = new Configuration.ConfigurationBuilder().Build();
+            configuration.Properties[ConfigurationPath.ApiVersion] = 2;
 
             var nopService = new NopService();
             var launchReporter = new LaunchReporter(nopService, configuration, null, new ExtensionManager());

--- a/test/ReportPortal.Shared.Tests/Extensibility/ReportEvents/ReportEventsFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Extensibility/ReportEvents/ReportEventsFixture.cs
@@ -294,7 +294,7 @@ namespace ReportPortal.Shared.Tests.Extensibility.ReportEvents
             CreateLogItemRequest[] sentClientLogs = null;
 
             var clientMock = new MockServiceBuilder().Build();
-            clientMock.Setup(c => c.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>())).Callback<CreateLogItemRequest[]>(lgs => sentClientLogs = lgs);
+            clientMock.Setup(c => c.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).Callback<CreateLogItemRequest[]>(lgs => sentClientLogs = lgs);
             var client = clientMock.Object;
             var launch = new LaunchReporterBuilder(client).With(extManager).Build(1, 1, 3);
             launch.Sync();

--- a/test/ReportPortal.Shared.Tests/Extensibility/ReportEvents/ReportEventsFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Extensibility/ReportEvents/ReportEventsFixture.cs
@@ -8,6 +8,7 @@ using ReportPortal.Shared.Reporter;
 using ReportPortal.Shared.Tests.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Xunit;
 
 namespace ReportPortal.Shared.Tests.Extensibility.ReportEvents
@@ -294,7 +295,9 @@ namespace ReportPortal.Shared.Tests.Extensibility.ReportEvents
             CreateLogItemRequest[] sentClientLogs = null;
 
             var clientMock = new MockServiceBuilder().Build();
-            clientMock.Setup(c => c.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).Callback<CreateLogItemRequest[]>(lgs => sentClientLogs = lgs);
+            clientMock.Setup(c => c.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default))
+                .Callback<CreateLogItemRequest[], CancellationToken>((lgs, t) => sentClientLogs = lgs);
+
             var client = clientMock.Object;
             var launch = new LaunchReporterBuilder(client).With(extManager).Build(1, 1, 3);
             launch.Sync();

--- a/test/ReportPortal.Shared.Tests/Helpers/LaunchReporterBuilder.cs
+++ b/test/ReportPortal.Shared.Tests/Helpers/LaunchReporterBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using ReportPortal.Client.Abstractions;
 using ReportPortal.Client.Abstractions.Models;
 using ReportPortal.Client.Abstractions.Requests;
+using ReportPortal.Shared.Configuration;
 using ReportPortal.Shared.Extensibility;
 using ReportPortal.Shared.Internal.Delegating;
 using ReportPortal.Shared.Reporter;
@@ -16,6 +17,8 @@ namespace ReportPortal.Shared.Tests.Helpers
         }
 
         public IClientService Service { get; }
+
+        public IConfiguration Configuration { get; set; }
 
         public IRequestExecuterFactory RequestExecuterFactory { get; set; }
 
@@ -35,9 +38,16 @@ namespace ReportPortal.Shared.Tests.Helpers
             return this;
         }
 
+        public LaunchReporterBuilder WithConfiguration(IConfiguration configuration)
+        {
+            Configuration = configuration;
+
+            return this;
+        }
+
         public LaunchReporter Build(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
         {
-            var launchReporter = new LaunchReporter(Service, null, RequestExecuterFactory?.Create(), ExtensionManager);
+            var launchReporter = new LaunchReporter(Service, Configuration, RequestExecuterFactory?.Create(), ExtensionManager);
 
             var launchDateTime = DateTime.UtcNow;
 
@@ -67,7 +77,7 @@ namespace ReportPortal.Shared.Tests.Helpers
                     });
 
                     for (int l = 0; l < logsPerTest; l++)
-                    {
+                    {                      
                         testNode.Log(new CreateLogItemRequest
                         {
                             Level = LogLevel.Info,

--- a/test/ReportPortal.Shared.Tests/Helpers/LaunchReporterBuilder.cs
+++ b/test/ReportPortal.Shared.Tests/Helpers/LaunchReporterBuilder.cs
@@ -77,7 +77,7 @@ namespace ReportPortal.Shared.Tests.Helpers
                     });
 
                     for (int l = 0; l < logsPerTest; l++)
-                    {                      
+                    {
                         testNode.Log(new CreateLogItemRequest
                         {
                             Level = LogLevel.Info,

--- a/test/ReportPortal.Shared.Tests/Helpers/MockServiceBuilder.cs
+++ b/test/ReportPortal.Shared.Tests/Helpers/MockServiceBuilder.cs
@@ -14,15 +14,22 @@ namespace ReportPortal.Shared.Tests.Helpers
             var service = new Mock<IClientService>();
 
             service.Setup(s => s.Launch.StartAsync(It.IsAny<StartLaunchRequest>(), default)).Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default)).Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
 
             service.Setup(s => s.TestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default)).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
             service.Setup(s => s.TestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default)).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
 
+            service.Setup(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default)).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default)).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+
             service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest>(), default)).Returns(() => Task.FromResult(new LogItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest>(), default)).Returns(() => Task.FromResult(new LogItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
 
             service.Setup(s => s.TestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default)).Returns(() => Task.FromResult(new MessageResponse()));
+            service.Setup(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default)).Returns(() => Task.FromResult(new MessageResponse()));
 
             service.Setup(s => s.Launch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default)).Returns(() => Task.FromResult(new LaunchFinishedResponse { Link = "http://server:80/path/to/launch"}));
+            service.Setup(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default)).Returns(() => Task.FromResult(new LaunchFinishedResponse { Link = "http://server:80/path/to/launch" }));
 
             return service;
         }

--- a/test/ReportPortal.Shared.Tests/Helpers/MockServiceBuilder.cs
+++ b/test/ReportPortal.Shared.Tests/Helpers/MockServiceBuilder.cs
@@ -13,16 +13,16 @@ namespace ReportPortal.Shared.Tests.Helpers
         {
             var service = new Mock<IClientService>();
 
-            service.Setup(s => s.Launch.StartAsync(It.IsAny<StartLaunchRequest>())).Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.Launch.StartAsync(It.IsAny<StartLaunchRequest>(), default)).Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
 
-            service.Setup(s => s.TestItem.StartAsync(It.IsAny<StartTestItemRequest>())).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
-            service.Setup(s => s.TestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>())).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.TestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default)).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.TestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default)).Returns(() => Task.FromResult(new TestItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
 
-            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest>())).Returns(() => Task.FromResult(new LogItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest>(), default)).Returns(() => Task.FromResult(new LogItemCreatedResponse { Uuid = Guid.NewGuid().ToString() }));
 
-            service.Setup(s => s.TestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>())).Returns(() => Task.FromResult(new MessageResponse()));
+            service.Setup(s => s.TestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default)).Returns(() => Task.FromResult(new MessageResponse()));
 
-            service.Setup(s => s.Launch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>())).Returns(() => Task.FromResult(new LaunchFinishedResponse { Link = "http://server:80/path/to/launch"}));
+            service.Setup(s => s.Launch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default)).Returns(() => Task.FromResult(new LaunchFinishedResponse { Link = "http://server:80/path/to/launch"}));
 
             return service;
         }

--- a/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
@@ -32,7 +32,6 @@ namespace ReportPortal.Shared.Tests.Reporter
             _testReporter.SetupGet(r => r.StartTask).Returns(() => Task.FromResult(0));
             _testReporter.SetupGet(r => r.Info).Returns(() => new TestInfo { });
 
-
             _configuration = new ConfigurationBuilder().Build();
             _configuration.Properties[ConfigurationPath.ApiVersion] = 2;
 

--- a/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
@@ -33,7 +33,7 @@ namespace ReportPortal.Shared.Tests.Reporter
             _testReporter.SetupGet(r => r.Info).Returns(() => new TestInfo { });
 
             _configuration = new ConfigurationBuilder().Build();
-            _configuration.Properties[ConfigurationPath.ApiVersion] = 2;
+            _configuration.Properties[ConfigurationPath.AsyncReporting] = true;
 
             _requestExecuter = new NoneRetryRequestExecuter(null);
             _reportEventsSource = new ReportEventsSource();

--- a/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
@@ -1,0 +1,248 @@
+﻿using FluentAssertions;
+using Moq;
+using ReportPortal.Client.Abstractions.Requests;
+using ReportPortal.Shared.Configuration;
+using ReportPortal.Shared.Extensibility;
+using ReportPortal.Shared.Internal.Delegating;
+using ReportPortal.Shared.Reporter;
+using ReportPortal.Shared.Reporter.Statistics;
+using ReportPortal.Shared.Tests.Helpers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ReportPortal.Shared.Tests.Reporter
+{
+    public class AsyncLogsReporterFixture
+    {
+        readonly Mock<ITestReporter> _testReporter;
+        readonly IConfiguration _configuration;
+        readonly IRequestExecuter _requestExecuter;
+        readonly IExtensionManager _extensionManager;
+        readonly Mock<ILogRequestAmender> _logRequestAmender;
+        readonly ReportEventsSource _reportEventsSource;
+
+        public AsyncLogsReporterFixture()
+        {
+            _testReporter = new Mock<ITestReporter>();
+            _testReporter.SetupGet(r => r.StatisticsCounter).Returns(() => new LaunchStatisticsCounter());
+            _testReporter.SetupGet(r => r.StartTask).Returns(() => Task.FromResult(0));
+            _testReporter.SetupGet(r => r.Info).Returns(() => new TestInfo { });
+
+
+            _configuration = new ConfigurationBuilder().Build();
+            _configuration.Properties[ConfigurationPath.ApiVersion] = 2;
+
+            _requestExecuter = new NoneRetryRequestExecuter(null);
+            _reportEventsSource = new ReportEventsSource();
+
+            _extensionManager = new ExtensionManager();
+            _logRequestAmender = new Mock<ILogRequestAmender>();
+        }
+
+        [Fact]
+        public void ShouldSendRequestPerLogItem()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var logsReporter = new LogsReporter(
+                _testReporter.Object,
+                service.Object,
+                _configuration,
+                _extensionManager,
+                _requestExecuter,
+                _logRequestAmender.Object,
+                _reportEventsSource,
+                1);
+
+            for (int i = 0; i < 100; i++)
+            {
+                logsReporter.Log(new CreateLogItemRequest
+                {
+                    Text = "a",
+                    Time = DateTime.UtcNow
+                });
+            }
+
+            logsReporter.Sync();
+
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(100));
+        }
+
+        [Fact]
+        public void ShouldSendBatchedRequests()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var logsReporter = new LogsReporter(
+                _testReporter.Object,
+                service.Object,
+                _configuration,
+                _extensionManager,
+                _requestExecuter,
+                _logRequestAmender.Object,
+                _reportEventsSource, 
+                20);
+
+            for (int i = 0; i < 60; i++)
+            {
+                logsReporter.Log(new CreateLogItemRequest
+                {
+                    Text = "a",
+                    Time = DateTime.UtcNow
+                });
+            }
+
+            logsReporter.Sync();
+
+            // sometimes on slow machines it's not exact 3 invocations
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Between(3, 4, Moq.Range.Inclusive));
+        }
+
+        [Fact]
+        public void ShouldSendRequestsEvenIfPreviousFailed()
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).Throws<Exception>();
+
+            var logsReporter = new LogsReporter(
+                _testReporter.Object,
+                service.Object,
+                _configuration,
+                _extensionManager,
+                _requestExecuter,
+                _logRequestAmender.Object,
+                _reportEventsSource,
+                1);
+
+            for (int i = 0; i < 2; i++)
+            {
+                logsReporter.Log(new CreateLogItemRequest
+                {
+                    Text = "a",
+                    Time = DateTime.UtcNow
+                });
+            }
+
+            try
+            {
+                logsReporter.Sync();
+            }
+            catch (Exception) { }
+
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ShouldSendAsSeparateRequestPerLogWithAttachment()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var logsReporter = new LogsReporter(
+                _testReporter.Object,
+                service.Object,
+                _configuration,
+                _extensionManager,
+                _requestExecuter,
+                _logRequestAmender.Object,
+                _reportEventsSource,
+                20);
+
+            for (int i = 0; i < 2; i++)
+            {
+                logsReporter.Log(new CreateLogItemRequest
+                {
+                    Text = "a",
+                    Time = DateTime.UtcNow,
+                    Attach = new LogItemAttach()
+                });
+            }
+
+            logsReporter.Sync();
+
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ShouldSendAsSeparateRequestPerLogWithAttachmentIncludingWithoutAttachment()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var logsReporter = new LogsReporter(
+                _testReporter.Object,
+                service.Object,
+                _configuration, 
+                _extensionManager, 
+                _requestExecuter,
+                _logRequestAmender.Object,
+                _reportEventsSource,
+                20);
+
+            var withoutAttachment = new CreateLogItemRequest
+            {
+                Text = "a",
+                Time = DateTime.UtcNow
+            };
+            var withAttachment = new CreateLogItemRequest
+            {
+                Text = "a",
+                Time = DateTime.UtcNow,
+                Attach = new LogItemAttach()
+            };
+
+            logsReporter.Log(withAttachment);
+            logsReporter.Log(withoutAttachment);
+            logsReporter.Log(withAttachment);
+            logsReporter.Log(withoutAttachment);
+
+            logsReporter.Sync();
+
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ShouldBeThreadSafeWhenSchedulingLogRequests()
+        {
+            var logItemRequestTexts = new List<string>();
+
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default))
+                .Callback<CreateLogItemRequest[], CancellationToken>((rqs, t) =>
+                {
+                    foreach (var rq in rqs)
+                    {
+                        logItemRequestTexts.Add(rq.Text);
+                    }
+                })
+                .Returns(() => Task.FromResult(new Client.Abstractions.Responses.LogItemsCreatedResponse()));
+
+            var logsReporter = new LogsReporter(
+                _testReporter.Object,
+                service.Object,
+                _configuration,
+                _extensionManager,
+                _requestExecuter,
+                _logRequestAmender.Object,
+                _reportEventsSource,
+                20);
+
+            Parallel.For(0, 1000, (i) => logsReporter.Log(new CreateLogItemRequest
+            {
+                Text = i.ToString(),
+                Time = DateTime.UtcNow
+            }));
+
+            logsReporter.Sync();
+
+            // we have scheduled 1000 log items which will be consumed by 10 items in loop in background (happy path)
+            // sometimes consumer iterates faster than producer
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Between(50, 100, Moq.Range.Inclusive));
+
+            logItemRequestTexts.Should().HaveCount(1000);
+            logItemRequestTexts.Should().OnlyHaveUniqueItems();
+        }
+    }
+}

--- a/test/ReportPortal.Shared.Tests/Reporter/AsyncReporterTest.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/AsyncReporterTest.cs
@@ -1,0 +1,695 @@
+﻿using FluentAssertions;
+using Moq;
+using ReportPortal.Client.Abstractions.Requests;
+using ReportPortal.Client.Abstractions.Responses;
+using ReportPortal.Shared.Configuration;
+using ReportPortal.Shared.Extensibility;
+using ReportPortal.Shared.Reporter;
+using ReportPortal.Shared.Tests.Helpers;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ReportPortal.Shared.Tests.Reporter
+{
+    public class AsyncReporterTest
+    {
+        private readonly IConfiguration _configuration;
+
+        public AsyncReporterTest()
+        {
+            _configuration = new ConfigurationBuilder().Build();
+            _configuration.Properties[ConfigurationPath.ApiVersion] = 2;
+        }
+
+        [Theory]
+        [InlineData(1, 1, 0)]
+        [InlineData(1, 1, 1)]
+        [InlineData(5, 100, 0)]
+        [InlineData(10, 200, 10)]
+        public void SuccessReporting(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object).WithConfiguration(_configuration);
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            launchReporter.Sync();
+
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch + suitesPerLaunch));
+
+            service.Verify(s => s.TestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Never());
+            service.Verify(s => s.TestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Never());
+            service.Verify(s => s.TestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Never());
+
+            launchReporter.ChildTestReporters.Select(s => s.Info.Uuid).Should().OnlyHaveUniqueItems();
+            launchReporter.ChildTestReporters.SelectMany(s => s.ChildTestReporters).Select(t => t.Info.Uuid).Should().OnlyHaveUniqueItems();
+        }
+
+        [Theory]
+        [InlineData(1, 1, 10)]
+        public void ShouldInvokeSingleVersionOfEndpoint(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object).WithConfiguration(_configuration);
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            launchReporter.Sync();
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Once());
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch + suitesPerLaunch));
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once());
+
+            service.Verify(s => s.Launch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Never());
+            service.Verify(s => s.TestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Never());
+            service.Verify(s => s.TestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Never());
+            service.Verify(s => s.TestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Never());
+            service.Verify(s => s.Launch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Never());
+        }
+
+        [Fact]
+        public void ShouldFulfillTestInfo()
+        {
+            var now = DateTime.UtcNow;
+
+            var service = new MockServiceBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object).WithConfiguration(_configuration);
+            var launchReporter = launchScheduler.Build(1, 0, 0);
+
+            launchReporter.Sync();
+
+            var testReporter = launchReporter.ChildTestReporters[0];
+
+            testReporter.Should().NotBeNull();
+            testReporter.Info.Uuid.Should().NotBeNullOrEmpty();
+            testReporter.Info.Name.Should().NotBeNullOrEmpty();
+            testReporter.Info.StartTime.Should().BeCloseTo(now, precision: TimeSpan.FromMilliseconds(100));
+            testReporter.Info.FinishTime.Should().BeCloseTo(now, precision: TimeSpan.FromMilliseconds(100));
+            (testReporter.Info as TestInfo).Status.Should().Be(Client.Abstractions.Models.Status.Passed);
+        }
+
+        [Fact]
+        public void MixingTestsAndLogs()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launchReporter = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            launchReporter.Start(new StartLaunchRequest { StartTime = DateTime.UtcNow });
+
+            for (int i = 0; i < 10; i++)
+            {
+                var suite = launchReporter.StartChildTestReporter(new StartTestItemRequest { StartTime = DateTime.UtcNow });
+
+                suite.Log(new CreateLogItemRequest { Time = DateTime.UtcNow });
+
+                for (int j = 0; j < 20; j++)
+                {
+                    var test = suite.StartChildTestReporter(new StartTestItemRequest { StartTime = DateTime.UtcNow });
+
+                    test.Log(new CreateLogItemRequest { Time = DateTime.UtcNow });
+
+                    test.Finish(new FinishTestItemRequest { EndTime = DateTime.UtcNow });
+                }
+
+                suite.Log(new CreateLogItemRequest { Time = DateTime.UtcNow });
+
+                suite.Finish(new FinishTestItemRequest { EndTime = DateTime.UtcNow });
+            }
+
+            launchReporter.Finish(new FinishLaunchRequest { EndTime = DateTime.UtcNow });
+
+            launchReporter.Sync();
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(10, 10, 10)]
+        public void FailedLogsShouldNotAffectFinishingLaunch(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).Throws<Exception>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            launchReporter.Sync();
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Exactly(1));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch + suitesPerLaunch));
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(10, 10, 10)]
+        public void CanceledLogsShouldNotAffectFinishingLaunch(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest>(), default)).Throws<TaskCanceledException>();
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).Throws<TaskCanceledException>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            launchReporter.Sync();
+
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Exactly(testsPerSuite * suitesPerLaunch + suitesPerLaunch));
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(1, 1, 2)]
+        [InlineData(5, 5, 0)]
+        public void FailedFinishTestItemShouldRaiseExceptionAtFinishLaunch(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default)).Throws(new Exception());
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+            Assert.Contains("Cannot finish launch", exp.Message);
+
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch * testsPerSuite));
+            service.Verify(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Exactly(suitesPerLaunch * testsPerSuite));
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(10, 10, 2)]
+        [InlineData(50, 50, 0)]
+        public void CanceledFinishTestItemShouldRaiseExceptionAtFinishLaunch(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default)).Throws<TaskCanceledException>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+            Assert.Contains("Cannot finish launch", exp.Message);
+
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch * testsPerSuite));
+            service.Verify(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default), Times.Exactly(suitesPerLaunch * testsPerSuite));
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(100, 1, 1)]
+        [InlineData(1, 100, 100)]
+        [InlineData(100, 10, 1)]
+        public void FailedStartSuiteItemShouldRaiseExceptionAtFinishLaunch(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default)).Throws<Exception>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+            Assert.Contains("Cannot finish launch", exp.Message);
+
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(null, It.IsAny<StartTestItemRequest>(), default), Times.Never);
+            service.Verify(s => s.AsyncTestItem.FinishAsync(null, It.IsAny<FinishTestItemRequest>(), default), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(100, 1, 1)]
+        [InlineData(1, 10, 100)]
+        [InlineData(10, 10, 1)]
+        public void CanceledStartSuiteItemShouldRaiseExceptionAtFinishLaunch(int suitesPerLaunch, int testsPerSuite, int logsPerTest)
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default)).Throws<TaskCanceledException>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(suitesPerLaunch, testsPerSuite, logsPerTest);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+            Assert.Contains("Cannot finish launch", exp.Message);
+
+            service.Verify(s => s.AsyncTestItem.StartAsync(It.IsAny<StartTestItemRequest>(), default), Times.Exactly(suitesPerLaunch));
+            service.Verify(s => s.AsyncTestItem.StartAsync(null, It.IsAny<StartTestItemRequest>(), default), Times.Never);
+            service.Verify(s => s.AsyncTestItem.FinishAsync(null, It.IsAny<FinishTestItemRequest>(), default), Times.Never);
+            service.Verify(s => s.AsyncLaunch.FinishAsync(null, It.IsAny<FinishLaunchRequest>(), default), Times.Never);
+        }
+
+        [Fact]
+        public void StartLaunchScheduling()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launchReporters = new List<Mock<LaunchReporter>>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                var launchReporter = new Mock<LaunchReporter>(service.Object, _configuration, null, new ExtensionManager());
+
+                launchReporter.Object.Start(new StartLaunchRequest
+                {
+                    Name = $"ReportPortal Shared {i}",
+                    StartTime = DateTime.UtcNow
+                });
+
+                launchReporters.Add(launchReporter);
+            }
+
+            for (int i = 0; i < 100; i++)
+            {
+                var launchReporter = launchReporters[i];
+
+                Assert.NotNull(launchReporter.Object.StartTask);
+
+                launchReporter.Object.Sync();
+
+                Assert.Equal($"ReportPortal Shared {i}", launchReporter.Object.Info.Name);
+            }
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Exactly(100));
+        }
+
+        [Fact]
+        public void ShouldSyncNotStartedLaunch()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+
+            launch.Sync();
+        }
+
+        [Fact]
+        public void StartLaunchTimeout()
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default)).Throws<TaskCanceledException>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(1, 1, 1);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+        }
+
+        [Fact]
+        public void StartTestItemTimeout()
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncTestItem.StartAsync(It.IsAny<string>(), It.IsAny<StartTestItemRequest>(), default)).Throws<TaskCanceledException>();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(new MockRequestExecuterFactoryBuilder().Build().Object);
+
+            var launchReporter = launchScheduler.Build(1, 1, 1);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+            Assert.Contains("Cannot finish launch", exp.Message);
+        }
+
+        [Fact]
+        public void FinishTestItemTimeout()
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncTestItem.FinishAsync(It.IsAny<string>(), It.IsAny<FinishTestItemRequest>(), default)).Throws<TaskCanceledException>();
+
+            var requestExecuterFactory = new MockRequestExecuterFactoryBuilder().Build();
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object)
+                .WithConfiguration(_configuration)
+                .With(requestExecuterFactory.Object);
+
+            var launchReporter = launchScheduler.Build(1, 1, 1);
+
+            var exp = Assert.ThrowsAny<Exception>(() => launchReporter.Sync());
+            Assert.Contains("Cannot finish launch", exp.Message);
+
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Never);
+        }
+
+        [Fact]
+        public void LogsReportingShouldBeOneByOne()
+        {
+            var requests = new ConcurrentBag<CreateLogItemRequest[]>();
+
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default))
+                .ReturnsAsync(new LogItemsCreatedResponse())
+                .Callback<CreateLogItemRequest[], CancellationToken>((arg, t) => requests.Add(arg));
+
+            var launchScheduler = new LaunchReporterBuilder(service.Object).WithConfiguration(_configuration);
+            var launchReporter = launchScheduler.Build(1, 30, 30);
+
+            launchReporter.Sync();
+
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once);
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.AtLeast(30 * 30 / 20)); // logs batch size
+
+            foreach (var bufferedRequests in requests)
+            {
+                bufferedRequests.Select(r => r.Text).Should().BeInAscendingOrder();
+            }
+        }
+
+        [Fact]
+        public void FinishLaunchWhenChildTestItemIsNotScheduledToFinish()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            launch.Start(new StartLaunchRequest { });
+
+            var test = launch.StartChildTestReporter(new StartTestItemRequest { });
+
+            var exp = Assert.Throws<InsufficientExecutionStackException>(() => launch.Finish(new FinishLaunchRequest { }));
+            Assert.Contains("are not scheduled to finish yet", exp.Message);
+        }
+
+        [Fact]
+        public void FinishLaunchWhichIsAlreadyFinished()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest { });
+            launch.Finish(new FinishLaunchRequest());
+            launch.Invoking(l => l.Finish(new FinishLaunchRequest())).Should().Throw<InsufficientExecutionStackException>().And.Message.Should().Contain("already scheduled for finishing");
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenStartingAlreadyStartedTestItem()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest());
+            var test = launch.StartChildTestReporter(new StartTestItemRequest());
+            test.Invoking(t => t.Start(new StartTestItemRequest())).Should().ThrowExactly<InsufficientExecutionStackException>();
+        }
+
+        [Fact]
+        public void ShouldRerunLaunch()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            StartLaunchRequest startLaunchRequest = null;
+
+            service.Setup(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default))
+                .Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }))
+                .Callback<StartLaunchRequest, CancellationToken>((r, t) => startLaunchRequest = r);
+
+            var config = new ConfigurationBuilder().Build();
+
+            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties["Launch:Rerun"] = "true";
+
+            var launch = new LaunchReporter(service.Object, config, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+            launch.Finish(new FinishLaunchRequest() { EndTime = DateTime.UtcNow });
+            launch.Sync();
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Once);
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once);
+
+            startLaunchRequest.IsRerun.Should().BeTrue();
+            startLaunchRequest.RerunOfLaunchUuid.Should().BeNull();
+        }
+
+        [Fact]
+        public void ShouldRerunOfLaunchOnlyIfRerunIsSet()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            StartLaunchRequest startLaunchRequest = null;
+
+            service.Setup(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default))
+                .Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }))
+                .Callback<StartLaunchRequest, CancellationToken>((r, t) => startLaunchRequest = r);
+
+            var config = new ConfigurationBuilder().Build();
+
+            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties["Launch:Rerun"] = "true";
+            config.Properties["Launch:RerunOf"] = "any_uuid_of_existing_launch";
+
+            var launch = new LaunchReporter(service.Object, config, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+            launch.Finish(new FinishLaunchRequest() { EndTime = DateTime.UtcNow });
+            launch.Sync();
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Once);
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once);
+
+            startLaunchRequest.IsRerun.Should().BeTrue();
+            startLaunchRequest.RerunOfLaunchUuid.Should().Be("any_uuid_of_existing_launch");
+        }
+
+        [Fact]
+        public void ShouldNotRerunOfLaunchOnlyIfRerunIsSet()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            StartLaunchRequest startLaunchRequest = null;
+
+            service.Setup(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default))
+                .Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }))
+                .Callback<StartLaunchRequest, CancellationToken>((r, t) => startLaunchRequest = r);
+
+            var config = new ConfigurationBuilder().Build();
+
+            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties["Launch:Rerun"] = "false";
+            config.Properties["Launch:RerunOf"] = "any_uuid_of_existing_launch";
+
+            var launch = new LaunchReporter(service.Object, config, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+            launch.Finish(new FinishLaunchRequest() { EndTime = DateTime.UtcNow });
+            launch.Sync();
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Once);
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Once);
+
+            startLaunchRequest.IsRerun.Should().BeFalse();
+            startLaunchRequest.RerunOfLaunchUuid.Should().BeNull();
+        }
+
+        [Fact]
+        public void ShouldUseExternalLaunchEnsteadOfStartingNew()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            service.Setup(s => s.Launch.GetAsync(It.IsAny<string>(), default))
+                .Returns(Task.FromResult(new LaunchResponse { Uuid = "123" }));
+
+            var config = new ConfigurationBuilder().Build();
+            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties["Launch:Id"] = "any_uuid_of_existing_launch";
+
+            var launch = new LaunchReporter(service.Object, config, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+            launch.Finish(new FinishLaunchRequest() { EndTime = DateTime.UtcNow });
+            launch.Sync();
+
+            service.Verify(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default), Times.Never);
+            service.Verify(s => s.AsyncLaunch.FinishAsync(It.IsAny<string>(), It.IsAny<FinishLaunchRequest>(), default), Times.Never);
+
+            service.Verify(s => s.Launch.GetAsync(It.IsAny<string>(), default), Times.Once);
+
+            launch.Info.Uuid.Should().Be("123");
+        }
+
+        [Fact]
+        public void FinishLaunchWhichIsNotStarted()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, null, null, new ExtensionManager());
+            launch.Invoking(l => l.Finish(new FinishLaunchRequest())).Should().Throw<InsufficientExecutionStackException>().And.Message.Should().Contain("wasn't scheduled for starting");
+        }
+
+        [Fact]
+        public void StartingLaunchWhichIsAlreadyStarted()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            launch.Start(new StartLaunchRequest { });
+            launch.Invoking(l => l.Start(new StartLaunchRequest { })).Should().Throw<InsufficientExecutionStackException>().And.Message.Should().Contain("already scheduled for starting");
+        }
+
+        [Fact]
+        public void FinishTestItemWhenChildTestItemIsNotScheduledToFinish()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new Mock<IExtensionManager>().Object);
+            launch.Start(new StartLaunchRequest { });
+            var test = launch.StartChildTestReporter(new StartTestItemRequest());
+            var innerTest = test.StartChildTestReporter(new StartTestItemRequest());
+
+            var exp = Assert.Throws<InsufficientExecutionStackException>(() => test.Finish(new FinishTestItemRequest()));
+            Assert.Contains("are not scheduled to finish yet", exp.Message);
+        }
+
+        [Fact]
+        public void ShouldNotLogIfLaunchFailedToStart()
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.AsyncLaunch.StartAsync(It.IsAny<StartLaunchRequest>(), default)).Throws(new Exception());
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+
+            launch.Log(new CreateLogItemRequest { Time = DateTime.UtcNow, Text = "log" });
+
+            Action waitAct = () => launch.Sync();
+            waitAct.Should().Throw<Exception>();
+
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest>(), default), Times.Never);
+        }
+
+        [Fact]
+        public void FailedLaunchLogShouldNotBreakReporting()
+        {
+            var service = new MockServiceBuilder().Build();
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest>(), default)).Throws(new Exception());
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+            launch.Log(new CreateLogItemRequest { Time = DateTime.UtcNow, Text = "log" });
+            launch.Finish(new FinishLaunchRequest() { EndTime = DateTime.UtcNow });
+
+            launch.Sync();
+        }
+
+        [Fact]
+        public void ShouldBeAbleToLogIntoLaunch()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            launch.Start(new StartLaunchRequest() { StartTime = DateTime.UtcNow });
+            launch.Log(new CreateLogItemRequest { Time = DateTime.UtcNow, Text = "log" });
+            launch.Finish(new FinishLaunchRequest() { EndTime = DateTime.UtcNow });
+            launch.Sync();
+
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Once);
+        }
+
+        [Fact]
+        public void CannotLogIfLaunchNotStarted()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+            Action act = () => launch.Log(new CreateLogItemRequest { Time = DateTime.UtcNow, Text = "log" });
+
+            act.Should().Throw<InsufficientExecutionStackException>().WithMessage("*launch wasn't scheduled for starting*");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenLaunchStartingNullRequest()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+
+            Action act = () => launch.Start(null);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ShouldThrowWhenLaunchFinishingNullRequest()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+
+            launch.Start(new StartLaunchRequest());
+
+            Action act = () => launch.Finish(null);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ShouldThrowWhenTestStartingNullRequest()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+
+            launch.Start(new StartLaunchRequest());
+
+            Action act = () => launch.StartChildTestReporter(null);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ShouldThrowWhenTestFinishingNullRequest()
+        {
+            var service = new MockServiceBuilder().Build();
+
+            var launch = new LaunchReporter(service.Object, _configuration, null, new ExtensionManager());
+
+            launch.Start(new StartLaunchRequest());
+
+            var test = launch.StartChildTestReporter(new StartTestItemRequest());
+
+            Action act = () => test.Finish(null);
+            act.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/test/ReportPortal.Shared.Tests/Reporter/AsyncReporterTest.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/AsyncReporterTest.cs
@@ -23,7 +23,7 @@ namespace ReportPortal.Shared.Tests.Reporter
         public AsyncReporterTest()
         {
             _configuration = new ConfigurationBuilder().Build();
-            _configuration.Properties[ConfigurationPath.ApiVersion] = 2;
+            _configuration.Properties[ConfigurationPath.AsyncReporting] = true;
         }
 
         [Theory]
@@ -453,7 +453,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             var config = new ConfigurationBuilder().Build();
 
-            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties[ConfigurationPath.AsyncReporting] = true;
             config.Properties["Launch:Rerun"] = "true";
 
             var launch = new LaunchReporter(service.Object, config, null, new Mock<IExtensionManager>().Object);
@@ -481,7 +481,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             var config = new ConfigurationBuilder().Build();
 
-            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties[ConfigurationPath.AsyncReporting] = true;
             config.Properties["Launch:Rerun"] = "true";
             config.Properties["Launch:RerunOf"] = "any_uuid_of_existing_launch";
 
@@ -509,8 +509,8 @@ namespace ReportPortal.Shared.Tests.Reporter
                 .Callback<StartLaunchRequest, CancellationToken>((r, t) => startLaunchRequest = r);
 
             var config = new ConfigurationBuilder().Build();
-
-            config.Properties[ConfigurationPath.ApiVersion] = 2;
+    
+            config.Properties[ConfigurationPath.AsyncReporting] = true;
             config.Properties["Launch:Rerun"] = "false";
             config.Properties["Launch:RerunOf"] = "any_uuid_of_existing_launch";
 
@@ -535,7 +535,7 @@ namespace ReportPortal.Shared.Tests.Reporter
                 .Returns(Task.FromResult(new LaunchResponse { Uuid = "123" }));
 
             var config = new ConfigurationBuilder().Build();
-            config.Properties[ConfigurationPath.ApiVersion] = 2;
+            config.Properties[ConfigurationPath.AsyncReporting] = true;
             config.Properties["Launch:Id"] = "any_uuid_of_existing_launch";
 
             var launch = new LaunchReporter(service.Object, config, null, new Mock<IExtensionManager>().Object);

--- a/test/ReportPortal.Shared.Tests/Reporter/LogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/LogsReporterFixture.cs
@@ -57,7 +57,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             logsReporter.Sync();
 
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.Exactly(50));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(50));
         }
 
         [Fact]
@@ -79,14 +79,14 @@ namespace ReportPortal.Shared.Tests.Reporter
             logsReporter.Sync();
 
             // sometimes on slow machines it's not exact 3 invocations
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.Between(3, 4, Moq.Range.Inclusive));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Between(3, 4, Moq.Range.Inclusive));
         }
 
         [Fact]
         public void ShouldSendRequestsEvenIfPreviousFailed()
         {
             var service = new MockServiceBuilder().Build();
-            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>())).Throws<Exception>();
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).Throws<Exception>();
 
             var logsReporter = new LogsReporter(_testReporter.Object, service.Object, _configuration, _extensionManager, _requestExecuter, _logRequestAmender.Object, _reportEventsSource, 1);
 
@@ -105,7 +105,7 @@ namespace ReportPortal.Shared.Tests.Reporter
             }
             catch (Exception) { }
 
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.Exactly(2));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             logsReporter.Sync();
 
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.Exactly(2));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             logsReporter.Sync();
 
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.Exactly(2));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace ReportPortal.Shared.Tests.Reporter
             var logItemRequestTexts = new List<string>();
 
             var service = new MockServiceBuilder().Build();
-            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()))
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default))
                 .Callback<CreateLogItemRequest[]>(rqs => { foreach (var rq in rqs) logItemRequestTexts.Add(rq.Text); })
                 .Returns(() => Task.FromResult(new Client.Abstractions.Responses.LogItemsCreatedResponse()));
 
@@ -181,7 +181,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             // we have scheduled 1000 log items which will be consumed by 10 items in loop in background (happy path)
             // sometimes consumer iterates faster than producer
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>()), Times.Between(50, 100, Moq.Range.Inclusive));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Between(50, 100, Moq.Range.Inclusive));
 
             logItemRequestTexts.Should().HaveCount(1000);
             logItemRequestTexts.Should().OnlyHaveUniqueItems();

--- a/test/ReportPortal.Shared.Tests/Reporter/LogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/LogsReporterFixture.cs
@@ -9,6 +9,7 @@ using ReportPortal.Shared.Reporter.Statistics;
 using ReportPortal.Shared.Tests.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -166,7 +167,13 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             var service = new MockServiceBuilder().Build();
             service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default))
-                .Callback<CreateLogItemRequest[]>(rqs => { foreach (var rq in rqs) logItemRequestTexts.Add(rq.Text); })
+                .Callback<CreateLogItemRequest[], CancellationToken>((rqs, t) =>
+                {
+                    foreach (var rq in rqs)
+                    {
+                        logItemRequestTexts.Add(rq.Text);
+                    }
+                })
                 .Returns(() => Task.FromResult(new Client.Abstractions.Responses.LogItemsCreatedResponse()));
 
             var logsReporter = new LogsReporter(_testReporter.Object, service.Object, _configuration, _extensionManager, _requestExecuter, _logRequestAmender.Object, _reportEventsSource, 20);

--- a/test/ReportPortal.Shared.Tests/Reporter/ReporterTest.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/ReporterTest.cs
@@ -338,8 +338,9 @@ namespace ReportPortal.Shared.Tests.Reporter
             var requests = new ConcurrentBag<CreateLogItemRequest[]>();
 
             var service = new MockServiceBuilder().Build();
-            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default)).ReturnsAsync(new LogItemsCreatedResponse())
-                .Callback<CreateLogItemRequest[]>((arg) => requests.Add(arg));
+            service.Setup(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default))
+                .ReturnsAsync(new LogItemsCreatedResponse())
+                .Callback<CreateLogItemRequest[], CancellationToken>((arg, t) => requests.Add(arg));
 
             var launchScheduler = new LaunchReporterBuilder(service.Object);
             var launchReporter = launchScheduler.Build(1, 30, 30);
@@ -433,7 +434,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             service.Setup(s => s.Launch.StartAsync(It.IsAny<StartLaunchRequest>(), default))
                 .Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }))
-                .Callback<StartLaunchRequest>(r => startLaunchRequest = r);
+                .Callback<StartLaunchRequest, CancellationToken>((r, t) => startLaunchRequest = r);
 
             var config = new Shared.Configuration.ConfigurationBuilder().Build();
             config.Properties["Launch:Rerun"] = "true";
@@ -486,7 +487,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             service.Setup(s => s.Launch.StartAsync(It.IsAny<StartLaunchRequest>(), default))
                 .Returns(() => Task.FromResult(new LaunchCreatedResponse { Uuid = Guid.NewGuid().ToString() }))
-                .Callback<StartLaunchRequest>(r => startLaunchRequest = r);
+                .Callback<StartLaunchRequest, CancellationToken>((r, t) => startLaunchRequest = r);
 
             var config = new Shared.Configuration.ConfigurationBuilder().Build();
             config.Properties["Launch:Rerun"] = "false";


### PR DESCRIPTION
- Updated launch/test/log reporters.
- Updated already existing unit tests and added new onces for async reporters.
- Updated project with banchmark project.
- Updated documentation.