### PR TITLE
Sync method should wait all nested scheduled requests even if finishtask is null

### DIFF
--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -318,6 +318,16 @@ namespace ReportPortal.Shared.Reporter
         {
             StartTask?.GetAwaiter().GetResult();
 
+            if (ChildTestReporters != null)
+            {
+                foreach (var testNode in ChildTestReporters)
+                {
+                    testNode.Sync();
+                }
+            }
+
+            _logsReporter?.Sync();
+
             FinishTask?.GetAwaiter().GetResult();
         }
 

--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -316,19 +316,24 @@ namespace ReportPortal.Shared.Reporter
 
         public void Sync()
         {
-            StartTask?.GetAwaiter().GetResult();
-
-            if (ChildTestReporters != null)
+            if (FinishTask != null)
             {
-                foreach (var testNode in ChildTestReporters)
-                {
-                    testNode.Sync();
-                }
+                FinishTask.GetAwaiter().GetResult();
             }
+            else
+            {
+                StartTask?.GetAwaiter().GetResult();
 
-            _logsReporter?.Sync();
+                if (ChildTestReporters != null)
+                {
+                    foreach (var testNode in ChildTestReporters)
+                    {
+                        testNode.Sync();
+                    }
+                }
 
-            FinishTask?.GetAwaiter().GetResult();
+                _logsReporter?.Sync();
+            }
         }
 
         private LaunchInitializingEventArgs NotifyInitializing()

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -101,7 +101,15 @@ namespace ReportPortal.Shared.Reporter
 
         public void Sync()
         {
-            ProcessingTask?.GetAwaiter().GetResult();
+            try
+            {
+                ProcessingTask?.GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // we don't aware of failed requests for sending log messages (for now)
+            }
+
         }
 
         private List<CreateLogItemRequest> GetBufferedLogRequests(int batchCapacity)

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -302,6 +302,16 @@ namespace ReportPortal.Shared.Reporter
         {
             StartTask?.GetAwaiter().GetResult();
 
+            if (ChildTestReporters != null)
+            {
+                foreach (var testNode in ChildTestReporters)
+                {
+                    testNode.Sync();
+                }
+            }
+
+            _logsReporter?.Sync();
+
             FinishTask?.GetAwaiter().GetResult();
         }
 

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -300,19 +300,24 @@ namespace ReportPortal.Shared.Reporter
 
         public void Sync()
         {
-            StartTask?.GetAwaiter().GetResult();
-
-            if (ChildTestReporters != null)
+            if (FinishTask != null)
             {
-                foreach (var testNode in ChildTestReporters)
-                {
-                    testNode.Sync();
-                }
+                FinishTask.GetAwaiter().GetResult();
             }
+            else
+            {
+                StartTask?.GetAwaiter().GetResult();
 
-            _logsReporter?.Sync();
+                if (ChildTestReporters != null)
+                {
+                    foreach (var testNode in ChildTestReporters)
+                    {
+                        testNode.Sync();
+                    }
+                }
 
-            FinishTask?.GetAwaiter().GetResult();
+                _logsReporter?.Sync();
+            }
         }
 
         private BeforeTestStartingEventArgs NotifyStarting(StartTestItemRequest request)


### PR DESCRIPTION
Method `Sync()` waits all nested requests to be finished even if launch/test is not scheduled to be finished.

Fixes #113 