### PR TITLE
Add support to disable ignoring SSL errors

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -33,7 +33,16 @@ It's easier to define some property in any textual file. Agent finds all these f
 ## Environment variables
 Sometimes it's useful to specify configuration properties via environment variables. To specify `Section1:PropertyAbc` property just set environment variable with `ReportPortal_Section1_PropertyAbc` or `ReportPortal__Section1__PropertyAbc` name. We provide ability use `_` or `__` as a delimiter of nested variables. In case if you decided to use `_` as a delimiter, variable names should be started from `RP_` or `ReportPortal_`. Otherwise, variable names should be started from `RP__` or `ReportPortal__`. Variable names are case-insensitive.
 
+# General
+
+`Server:Project` - the name of your (pre-existing) project in ReportPortal server.
+
 # HTTP
+
+`Server:Url` - url to your ReportPortal server, including protocol and ports, e.g. `https://reportportal.example.com` or `https://reportportal.example.com:8080`.
+`Server:Authentication:Uuid` - access token to submit results to ReportPortal. You can find this in your user profile.
+`Server:IgnoreSslErrors` - ignores SSL / TLS errors. Defaults to `true` for backwards compatibility. This can be helpful when using self-signed certificates, however it is recommended to set this to `false`.
+
 ## Proxy
 `Server:Proxy:Url` - url to proxy server to be used for http requests like `http://myproxy.corp:8080`.
 `Server:Proxy:Username`, `Server:Proxy:Domain` and `Server:Proxy:Password` to specify credentials for proxy server which require authorization.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -41,7 +41,7 @@ Sometimes it's useful to specify configuration properties via environment variab
 
 `Server:Url` - url to your ReportPortal server, including protocol and ports, e.g. `https://reportportal.example.com` or `https://reportportal.example.com:8080`.
 `Server:Authentication:Uuid` - access token to submit results to ReportPortal. You can find this in your user profile.
-`Server:IgnoreSslErrors` - ignores SSL / TLS errors. Defaults to `true` for backwards compatibility. This can be helpful when using self-signed certificates, however it is recommended to set this to `false`.
+`Server:IgnoreSslErrors` - ignores SSL / TLS errors. Defaults to `false`. This can be helpful when using self-signed certificates, however this can make the connection susceptible to [man-in-the-middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) attacks.
 
 ## Proxy
 `Server:Proxy:Url` - url to proxy server to be used for http requests like `http://myproxy.corp:8080`.

--- a/src/ReportPortal.Shared/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserver.cs
+++ b/src/ReportPortal.Shared/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserver.cs
@@ -4,6 +4,7 @@ using System;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
+using ReportPortal.Shared.Configuration;
 
 namespace ReportPortal.Shared.Extensibility.Embedded.Analytics
 {
@@ -26,13 +27,21 @@ namespace ReportPortal.Shared.Extensibility.Embedded.Analytics
 
         private readonly HttpClient _httpClient;
 
-        public AnalyticsReportEventsObserver() : this(new HttpClientHandler
+        public AnalyticsReportEventsObserver(IConfiguration configuration) : this(CreateHttpMessageHandler(configuration))
         {
+        }
+
+        private static HttpMessageHandler CreateHttpMessageHandler(IConfiguration configuration) 
+        {
+            var handler = new HttpClientHandler();
+            
 #if !NET462
-            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
+            if (configuration.GetValue("Server:IgnoreSslErrors", true)) 
+            {
+                handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+            }
 #endif
-        })
-        {
+            return handler;
         }
 
         public AnalyticsReportEventsObserver(HttpMessageHandler httpHandler)

--- a/src/ReportPortal.Shared/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserver.cs
+++ b/src/ReportPortal.Shared/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserver.cs
@@ -111,13 +111,15 @@ namespace ReportPortal.Shared.Extensibility.Embedded.Analytics
                     return _httpClient;
                 
                 var handler = new HttpClientHandler();
+                var ignoreSslErrors = configuration.GetValue<bool>("Server:IgnoreSslErrors", false);
+
 #if NET462
-                if (configuration.GetValue("Server:IgnoreSslErrors", true)) 
+                if (ignoreSslErrors)
                 {
                     ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
                 }
 #else
-                if (configuration.GetValue("Server:IgnoreSslErrors", true)) 
+                if (ignoreSslErrors) 
                 {
                     handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
                 }

--- a/src/ReportPortal.Shared/Reporter/Http/HttpClientHandlerFactory.cs
+++ b/src/ReportPortal.Shared/Reporter/Http/HttpClientHandlerFactory.cs
@@ -38,17 +38,17 @@ namespace ReportPortal.Shared.Reporter.Http
 
             var ignoreSslErrors = Configuration.GetValue<bool>("Server:IgnoreSslErrors", true);
             
-#if NETSTANDARD2_0
-            if (ignoreSslErrors)            
-            {
-                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
-            }
-#else
+#if NET462
             if (ignoreSslErrors)
             {
                 ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
             }
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+#else
+            if (ignoreSslErrors)            
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
+            }
 #endif
 
             return httpClientHandler;

--- a/src/ReportPortal.Shared/Reporter/Http/HttpClientHandlerFactory.cs
+++ b/src/ReportPortal.Shared/Reporter/Http/HttpClientHandlerFactory.cs
@@ -36,10 +36,18 @@ namespace ReportPortal.Shared.Reporter.Http
 
             httpClientHandler.Proxy = GetProxy();
 
+            var ignoreSslErrors = Configuration.GetValue<bool>("Server:IgnoreSslErrors", true);
+            
 #if NETSTANDARD2_0
-            httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
+            if (ignoreSslErrors)            
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
+            }
 #else
-            ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
+            if (ignoreSslErrors)
+            {
+                ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
+            }
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 #endif
 

--- a/src/ReportPortal.Shared/Reporter/Http/HttpClientHandlerFactory.cs
+++ b/src/ReportPortal.Shared/Reporter/Http/HttpClientHandlerFactory.cs
@@ -36,7 +36,7 @@ namespace ReportPortal.Shared.Reporter.Http
 
             httpClientHandler.Proxy = GetProxy();
 
-            var ignoreSslErrors = Configuration.GetValue<bool>("Server:IgnoreSslErrors", true);
+            var ignoreSslErrors = Configuration.GetValue<bool>("Server:IgnoreSslErrors", false);
             
 #if NET462
             if (ignoreSslErrors)

--- a/test/ReportPortal.Shared.Tests/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserverTest.cs
+++ b/test/ReportPortal.Shared.Tests/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserverTest.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Web;
+using ReportPortal.Shared.Configuration;
 using Xunit;
 
 namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
@@ -90,9 +91,18 @@ namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
         [Fact]
         public void ShouldThrowIfEventsSourceIsNull()
         {
-            var ga = new AnalyticsReportEventsObserver();
+            var configuration = new ConfigurationBuilder().Build();
+            var ga = new AnalyticsReportEventsObserver(configuration);
 
             Action act = () => ga.Initialize(reportEventsSource: null);
+
+            act.Should().Throw<ArgumentNullException>();
+        }
+        
+        [Fact]
+        public void ShouldThrowIfConfigurationIsNull()
+        {
+            Action act = () => new AnalyticsReportEventsObserver(configuration: null);
 
             act.Should().Throw<ArgumentNullException>();
         }
@@ -100,7 +110,8 @@ namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
         [Fact]
         public void ShouldBeSilentIfLaunchIsNotStartedButFinished()
         {
-            var ga = new AnalyticsReportEventsObserver();
+            var configuration = new ConfigurationBuilder().Build();
+            var ga = new AnalyticsReportEventsObserver(configuration);
 
             var launchReporter = new Mock<ILaunchReporter>();
 
@@ -114,7 +125,8 @@ namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
         [Fact]
         public void ShouldDispose()
         {
-            var ga = new AnalyticsReportEventsObserver();
+            var configuration = new ConfigurationBuilder().Build();
+            var ga = new AnalyticsReportEventsObserver(configuration);
 
             ga.Initialize(new ReportEventsSource());
 

--- a/test/ReportPortal.Shared.Tests/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserverTest.cs
+++ b/test/ReportPortal.Shared.Tests/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserverTest.cs
@@ -13,7 +13,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Web;
-using ReportPortal.Shared.Configuration;
 using Xunit;
 
 namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
@@ -91,14 +90,12 @@ namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
         [Fact]
         public void ShouldThrowIfEventsSourceIsNull()
         {
-            var configuration = new ConfigurationBuilder().Build();
             var ga = new AnalyticsReportEventsObserver();
 
             Action act = () => ga.Initialize(reportEventsSource: null);
 
             act.Should().Throw<ArgumentNullException>();
         }
-
 
         [Fact]
         public void ShouldBeSilentIfLaunchIsNotStartedButFinished()

--- a/test/ReportPortal.Shared.Tests/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserverTest.cs
+++ b/test/ReportPortal.Shared.Tests/Extensibility/Embedded/Analytics/AnalyticsReportEventsObserverTest.cs
@@ -92,26 +92,18 @@ namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
         public void ShouldThrowIfEventsSourceIsNull()
         {
             var configuration = new ConfigurationBuilder().Build();
-            var ga = new AnalyticsReportEventsObserver(configuration);
+            var ga = new AnalyticsReportEventsObserver();
 
             Action act = () => ga.Initialize(reportEventsSource: null);
 
             act.Should().Throw<ArgumentNullException>();
         }
-        
-        [Fact]
-        public void ShouldThrowIfConfigurationIsNull()
-        {
-            Action act = () => new AnalyticsReportEventsObserver(configuration: null);
 
-            act.Should().Throw<ArgumentNullException>();
-        }
 
         [Fact]
         public void ShouldBeSilentIfLaunchIsNotStartedButFinished()
         {
-            var configuration = new ConfigurationBuilder().Build();
-            var ga = new AnalyticsReportEventsObserver(configuration);
+            var ga = new AnalyticsReportEventsObserver();
 
             var launchReporter = new Mock<ILaunchReporter>();
 
@@ -125,8 +117,7 @@ namespace ReportPortal.Shared.Tests.Extensibility.Embedded.Analytics
         [Fact]
         public void ShouldDispose()
         {
-            var configuration = new ConfigurationBuilder().Build();
-            var ga = new AnalyticsReportEventsObserver(configuration);
+            var ga = new AnalyticsReportEventsObserver();
 
             ga.Initialize(new ReportEventsSource());
 


### PR DESCRIPTION
I found that the code always ignores SSL errors, which isn't great - we'd rather rely on SSL errors to know if there are any MitM attacks.

This PR adds a flag to allow you to choose whether to ignore SSL errors, but defaults it to true, so that it's backwards compatible.

This is a similar PR to https://github.com/reportportal/client-net/pull/114, and will probably need updating when that one merges.

Note: I haven't done any specific testing of this PR yet.