### PR TITLE
Less memory allocation while processing log requests

### DIFF
--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -181,6 +181,7 @@ namespace ReportPortal.Shared.Reporter
 
             if (_logsReporter != null)
             {
+                _logsReporter.Finish();
                 dependentTasks.Add(_logsReporter.ProcessingTask);
             }
 

--- a/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LaunchReporter.cs
@@ -317,6 +317,8 @@ namespace ReportPortal.Shared.Reporter
 
         public void Sync()
         {
+            _logsReporter?.Sync();
+
             if (FinishTask != null)
             {
                 FinishTask.GetAwaiter().GetResult();
@@ -324,16 +326,14 @@ namespace ReportPortal.Shared.Reporter
             else
             {
                 StartTask?.GetAwaiter().GetResult();
+            }
 
-                if (ChildTestReporters != null)
+            if (ChildTestReporters != null)
+            {
+                foreach (var testNode in ChildTestReporters)
                 {
-                    foreach (var testNode in ChildTestReporters)
-                    {
-                        testNode.Sync();
-                    }
+                    testNode.Sync();
                 }
-
-                _logsReporter?.Sync();
             }
         }
 

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -6,6 +6,7 @@ using ReportPortal.Shared.Extensibility.ReportEvents.EventArgs;
 using ReportPortal.Shared.Internal.Delegating;
 using ReportPortal.Shared.Internal.Logging;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,6 +15,8 @@ namespace ReportPortal.Shared.Reporter
     public class LogsReporter : ILogsReporter
     {
         private static ITraceLogger TraceLogger { get; } = TraceLogManager.Instance.GetLogger<LogsReporter>();
+
+        private readonly BlockingCollection<CreateLogItemRequest> _queue = new BlockingCollection<CreateLogItemRequest>();
 
         private readonly Queue<CreateLogItemRequest> _buffer = new Queue<CreateLogItemRequest>();
 
@@ -49,102 +52,115 @@ namespace ReportPortal.Shared.Reporter
 
             if (batchCapacity < 1) throw new ArgumentException("Batch capacity for logs processing cannot be less than 1.", nameof(batchCapacity));
             BatchCapacity = batchCapacity;
-        }
 
-        private readonly object _syncObj = new object();
+            ProcessingTask = _reporter.StartTask.ContinueWith(async consumer =>
+            {
+                await ConsumeLogRequests();
+            });
+        }
 
         public int BatchCapacity { get; }
 
         public void Log(CreateLogItemRequest logRequest)
         {
-            lock (_syncObj)
-            {
-                _buffer.Enqueue(logRequest);
+            _queue.Add(logRequest);
+        }
 
-                var dependentTask = ProcessingTask ?? _reporter.StartTask;
-
-                ProcessingTask = dependentTask.ContinueWith(async (dt) =>
-                {
-                    try
-                    {
-                        // only if parent reporter is successful
-                        if (!_reporter.StartTask.IsFaulted && !_reporter.StartTask.IsCanceled)
-                        {
-                            var requests = GetBufferedLogRequests(batchCapacity: BatchCapacity);
-
-                            if (requests.Count != 0)
-                            {
-                                foreach (var logItemRequest in requests)
-                                {
-                                    _logRequestAmender.Amend(logItemRequest);
-                                }
-
-                                NotifySending(requests);
-
-                                await _requestExecuter
-                                    .ExecuteAsync(async () => _asyncReporting
-                                        ? await _service.AsyncLogItem.CreateAsync(requests.ToArray())
-                                        : await _service.LogItem.CreateAsync(requests.ToArray()), null, _reporter.StatisticsCounter.LogItemStatisticsCounter)
-                                    .ConfigureAwait(false);
-
-                                NotifySent(requests.AsReadOnly());
-                            }
-                        }
-                    }
-                    catch (Exception exp)
-                    {
-                        TraceLogger.Error($"Unexpected error occurred while processing buffered log requests. {exp}");
-                    }
-                }, TaskContinuationOptions.PreferFairness).Unwrap();
-            }
+        public void Finish()
+        {
+            _queue.CompleteAdding();
         }
 
         public void Sync()
         {
             try
             {
+                Finish();
+
                 ProcessingTask?.GetAwaiter().GetResult();
             }
             catch
             {
                 // we don't aware of failed requests for sending log messages (for now)
             }
-
         }
 
-        private List<CreateLogItemRequest> GetBufferedLogRequests(int batchCapacity)
+        private async Task ConsumeLogRequests()
         {
-            var requests = new List<CreateLogItemRequest>();
-
-            var batchContainsItemWithAttachment = false;
-
-            lock (_syncObj)
+            try
             {
-                for (int i = 0; i < batchCapacity; i++)
+                foreach (var logRequest in _queue.GetConsumingEnumerable())
                 {
-                    if (_buffer.Count > 0)
+                    if (logRequest.Attach != null)
                     {
-                        var logItemRequest = _buffer.Peek();
+                        await SendLogRequests(new List<CreateLogItemRequest> { logRequest });
+                    }
+                    else
+                    {
+                        var buffer = new List<CreateLogItemRequest>
+                    {
+                        logRequest
+                    };
 
-                        if (logItemRequest.Attach != null && batchContainsItemWithAttachment)
+                        for (int i = 0; i < BatchCapacity - 1; i++)
                         {
-                            break;
-                        }
-                        else
-                        {
-                            if (logItemRequest.Attach != null)
+                            if (_queue.TryTake(out var nextLogRequest))
                             {
-                                batchContainsItemWithAttachment = true;
-                            }
+                                if (nextLogRequest.Attach != null)
+                                {
+                                    await SendLogRequests(buffer);
 
-                            requests.Add(_buffer.Dequeue());
+                                    buffer.Clear();
+
+                                    await SendLogRequests(new List<CreateLogItemRequest> { nextLogRequest });
+                                }
+                                else
+                                {
+                                    buffer.Add(nextLogRequest);
+                                }
+                            }
+                        }
+
+                        if (buffer.Count > 0)
+                        {
+                            await SendLogRequests(buffer);
                         }
                     }
                 }
-
             }
+            catch (Exception ex)
+            {
+                TraceLogger.Error($"Unexpected error occurred while processing buffered log requests. {ex}");
+            }
+        }
 
-            return requests;
+        private async Task SendLogRequests(List<CreateLogItemRequest> logRequests)
+        {
+            // only if parent reporter is successful
+            if (!_reporter.StartTask.IsFaulted && !_reporter.StartTask.IsCanceled)
+            {
+                try
+                {
+                    foreach (var logItemRequest in logRequests)
+                    {
+                        _logRequestAmender.Amend(logItemRequest);
+                    }
+
+                    NotifySending(logRequests);
+
+                    await _requestExecuter
+                        .ExecuteAsync(async () => _asyncReporting
+                            ? await _service.AsyncLogItem.CreateAsync(logRequests.ToArray())
+                            : await _service.LogItem.CreateAsync(logRequests.ToArray()), null, _reporter.StatisticsCounter.LogItemStatisticsCounter)
+                        .ConfigureAwait(false);
+
+                    NotifySent(logRequests.AsReadOnly());
+                }
+                catch (Exception ex)
+                {
+                    TraceLogger.Error($"Unexpected error occurred while sending log requests. {ex}");
+                }
+            }
         }
 
         private BeforeLogsSendingEventArgs NotifySending(IList<CreateLogItemRequest> requests)

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -56,7 +56,7 @@ namespace ReportPortal.Shared.Reporter
             ProcessingTask = _reporter.StartTask.ContinueWith(async consumer =>
             {
                 await ConsumeLogRequests();
-            });
+            }).Unwrap();
         }
 
         public int BatchCapacity { get; }
@@ -98,9 +98,9 @@ namespace ReportPortal.Shared.Reporter
                     else
                     {
                         var buffer = new List<CreateLogItemRequest>
-                    {
-                        logRequest
-                    };
+                            {
+                                logRequest
+                            };
 
                         for (int i = 0; i < BatchCapacity - 1; i++)
                         {

--- a/src/ReportPortal.Shared/Reporter/LogsReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/LogsReporter.cs
@@ -18,8 +18,6 @@ namespace ReportPortal.Shared.Reporter
 
         private readonly BlockingCollection<CreateLogItemRequest> _queue = new BlockingCollection<CreateLogItemRequest>();
 
-        private readonly Queue<CreateLogItemRequest> _buffer = new Queue<CreateLogItemRequest>();
-
         private readonly bool _asyncReporting;
         private readonly IReporter _reporter;
         private readonly IClientService _service;

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -161,6 +161,7 @@ namespace ReportPortal.Shared.Reporter
 
             if (_logsReporter != null)
             {
+                _logsReporter.Finish();
                 dependentTasks.Add(_logsReporter.ProcessingTask);
             }
 

--- a/src/ReportPortal.Shared/Reporter/TestReporter.cs
+++ b/src/ReportPortal.Shared/Reporter/TestReporter.cs
@@ -301,6 +301,8 @@ namespace ReportPortal.Shared.Reporter
 
         public void Sync()
         {
+            _logsReporter?.Sync();
+
             if (FinishTask != null)
             {
                 FinishTask.GetAwaiter().GetResult();
@@ -308,16 +310,14 @@ namespace ReportPortal.Shared.Reporter
             else
             {
                 StartTask?.GetAwaiter().GetResult();
+            }
 
-                if (ChildTestReporters != null)
+            if (ChildTestReporters != null)
+            {
+                foreach (var testNode in ChildTestReporters)
                 {
-                    foreach (var testNode in ChildTestReporters)
-                    {
-                        testNode.Sync();
-                    }
+                    testNode.Sync();
                 }
-
-                _logsReporter?.Sync();
             }
         }
 

--- a/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
+++ b/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
@@ -44,47 +44,6 @@ namespace ReportPortal.Shared.Benchmark.Reporter
                     Type = TestItemType.Suite
                 });
 
-                suiteNode.Finish(new FinishTestItemRequest
-                {
-                    EndTime = launchDateTime,
-                    Status = Status.Passed
-                });
-            }
-
-            launchReporter.Finish(new FinishLaunchRequest
-            {
-                EndTime = launchDateTime
-            });
-
-            launchReporter.Sync();
-        }
-
-        [Benchmark]
-        public void LaunchReporterWithLogs()
-        {
-            var configuration = new ConfigurationBuilder().Build();
-
-            var nopService = new NopService();
-            var launchReporter = new LaunchReporter(nopService, configuration, null, new ExtensionManager());
-
-            var launchDateTime = DateTime.UtcNow;
-
-            launchReporter.Start(new StartLaunchRequest
-            {
-                Name = "ReportPortal Benchmark",
-                StartTime = launchDateTime,
-                Mode = LaunchMode.Debug
-            });
-
-            for (int i = 0; i < SuitesCount; i++)
-            {
-                var suiteNode = launchReporter.StartChildTestReporter(new StartTestItemRequest
-                {
-                    Name = $"Suite {i}",
-                    StartTime = launchDateTime.AddMilliseconds(-1),
-                    Type = TestItemType.Suite
-                });
-
                 for (int j = 0; j < LogsCount; j++)
                 {
                     suiteNode.Log(new CreateLogItemRequest { Text = "abc" });

--- a/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
+++ b/test/ReportPortal.Shared.Benchmark/Reporter/ReporterBenchmark.cs
@@ -21,8 +21,7 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         [Benchmark]
         public void LaunchReporter()
         {
-            var configuration = new Configuration.ConfigurationBuilder().Build();
-            configuration.Properties[ConfigurationPath.AsyncReporting] = true;
+            var configuration = new ConfigurationBuilder().Build();
 
             var nopService = new NopService();
             var launchReporter = new LaunchReporter(nopService, configuration, null, new ExtensionManager());
@@ -63,8 +62,7 @@ namespace ReportPortal.Shared.Benchmark.Reporter
         [Benchmark]
         public void LaunchReporterWithLogs()
         {
-            var configuration = new Configuration.ConfigurationBuilder().Build();
-            configuration.Properties[ConfigurationPath.AsyncReporting] = true;
+            var configuration = new ConfigurationBuilder().Build();
 
             var nopService = new NopService();
             var launchReporter = new LaunchReporter(nopService, configuration, null, new ExtensionManager());
@@ -87,7 +85,7 @@ namespace ReportPortal.Shared.Benchmark.Reporter
                     Type = TestItemType.Suite
                 });
 
-                for (int j = 0; j < 500; j++)
+                for (int j = 0; j < LogsCount; j++)
                 {
                     suiteNode.Log(new CreateLogItemRequest { Text = "abc" });
                 }

--- a/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/AsyncLogsReporterFixture.cs
@@ -9,7 +9,6 @@ using ReportPortal.Shared.Reporter.Statistics;
 using ReportPortal.Shared.Tests.Helpers;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -199,7 +198,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             logsReporter.Sync();
 
-            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
+            service.Verify(s => s.AsyncLogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(4));
         }
 
         [Fact]

--- a/test/ReportPortal.Shared.Tests/Reporter/LogsReporterFixture.cs
+++ b/test/ReportPortal.Shared.Tests/Reporter/LogsReporterFixture.cs
@@ -157,7 +157,7 @@ namespace ReportPortal.Shared.Tests.Reporter
 
             logsReporter.Sync();
 
-            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(2));
+            service.Verify(s => s.LogItem.CreateAsync(It.IsAny<CreateLogItemRequest[]>(), default), Times.Exactly(4));
         }
 
         [Fact]


### PR DESCRIPTION
Fix #137 

This technique can be applied to process all requests (start/finish launch/test).