### PR TITLE
UUID rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# MacOS auxiliary files
+.DS_Store

--- a/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
+++ b/src/ReportPortal.Shared/Configuration/ConfigurationPath.cs
@@ -1,4 +1,6 @@
-﻿namespace ReportPortal.Shared.Configuration
+﻿using System;
+
+namespace ReportPortal.Shared.Configuration
 {
     /// <summary>
     /// Stores well known configuration property names.
@@ -10,7 +12,9 @@
 
         public static readonly string ServerUrl = $"Server{KeyDelimeter}Url";
         public static readonly string ServerProject = $"Server{KeyDelimeter}Project";
+        [Obsolete("'Uuid' parameter is deprecated. Use 'ApiKey' instead.")]
         public static readonly string ServerAuthenticationUuid = $"Server{KeyDelimeter}Authentication{KeyDelimeter}Uuid";
+        public static readonly string ServerAuthenticationKey = $"Server{KeyDelimeter}Authentication{KeyDelimeter}ApiKey";
 
         public static readonly string LogsBatchCapacity = $"Server{KeyDelimeter}LogsBatchCapacity";
         public static readonly string AsyncReporting = $"Server{KeyDelimeter}AsyncReporting";

--- a/test/ReportPortal.Shared.Tests/ReportingTest.cs
+++ b/test/ReportPortal.Shared.Tests/ReportingTest.cs
@@ -32,7 +32,7 @@ namespace ReportPortal.Shared.Tests
             {
                 {ConfigurationPath.ServerUrl, "https://demo.reportportal.io/api/v1" },
                 {ConfigurationPath.ServerProject, "default_personal" },
-                {ConfigurationPath.ServerAuthenticationUuid, "695bb79b-0419-472f-bb7c-dd1e6e932a4f" }
+                {ConfigurationPath.ServerAuthenticationKey, "695bb79b-0419-472f-bb7c-dd1e6e932a4f" }
             });
 
             _service = new ClientServiceBuilder(config).Build();


### PR DESCRIPTION
Rename `UUID` configuration parameter to `ApiKey`, since it is not a UUID now. Keep backward compatibility.